### PR TITLE
`Feat`: disable auto reboot after updating Windows (#30)

### DIFF
--- a/src/scripts/optimize-privacy.ps1
+++ b/src/scripts/optimize-privacy.ps1
@@ -224,6 +224,10 @@ function Optimize-Privacy() {
     # [@] (0-23 = The time of day in 24-hour format)
     Set-ItemProperty -Path "$PathToLMPoliciesWindowsUpdate" -Name "ScheduledInstallTime" -Type DWord -Value 3
 
+    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) Automatic Reboot after update..."
+    # [@] (0 = Enable Automatic Reboot after update, 1 = Disable Automatic Reboot after update)
+    Set-ItemProperty -Path "$PathToLMPoliciesWindowsUpdate" -Name "NoAutoRebootWithLoggedOnUsers" -Type DWord -Value $One
+
     Write-Status -Symbol $EnableStatus[1].Symbol -Type $TweakType -Status "$($EnableStatus[1].Status) Change Windows Updates to 'Notify to schedule restart'..."
     Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\WindowsUpdate\UX\Settings" -Name "UxOption" -Type DWord -Value $One
 


### PR DESCRIPTION
Changes on this PR:
- On `optimize-privacy.ps1`, add a new tweak on the _Windows Update_ Section
- Closes #30