### PR TITLE
`fix`: Task Manager details tweak on Windows 11 (#33)

### DIFF
--- a/src/scripts/personal-tweaks.ps1
+++ b/src/scripts/personal-tweaks.ps1
@@ -17,6 +17,7 @@ function Register-PersonalTweaksList() {
         )
     )
     $TweakType = "Personal"
+    $WinVer = (Get-CimInstance -class Win32_OperatingSystem).Caption
 
     If ($Revert) {
         Write-Status -Symbol "<" -Type $TweakType -Status "Reverting the tweaks is set to '$Revert'." -Warning
@@ -46,15 +47,19 @@ function Register-PersonalTweaksList() {
     Open-RegFilesCollection -RelativeLocation "src\utils" -Scripts $Scripts -NoDialog
 
     # Show Task Manager details - Applicable to 1607 and later - Although this functionality exist even in earlier versions, the Task Manager's behavior is different there and is not compatible with this tweak
-    Write-Status -Symbol "+" -Type $TweakType -Status "Showing task manager details..."
-    $taskmgr = Start-Process -WindowStyle Hidden -FilePath taskmgr.exe -PassThru
-    Do {
-        Start-Sleep -Milliseconds 100
-        $preferences = Get-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\TaskManager" -Name "Preferences" -ErrorAction SilentlyContinue
-    } Until ($preferences)
-    Stop-Process $taskmgr
-    $preferences.Preferences[28] = 0
-    Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\TaskManager" -Name "Preferences" -Type Binary -Value $preferences.Preferences
+    If ((Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion" -Name CurrentBuild).CurrentBuild -lt 22557) {
+        Write-Status -Symbol "+" -Type $TweakType -Status "Showing task manager details..."
+        $taskmgr = Start-Process -WindowStyle Hidden -FilePath taskmgr.exe -PassThru
+        Do {
+            Start-Sleep -Milliseconds 100
+            $preferences = Get-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\TaskManager" -Name "Preferences" -ErrorAction SilentlyContinue
+        } Until ($preferences)
+        Stop-Process $taskmgr
+        $preferences.Preferences[28] = 0
+        Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\TaskManager" -Name "Preferences" -Type Binary -Value $preferences.Preferences
+    } Else {
+        Write-Status -Symbol "?" -Status "Task Manager patch not run in builds 22557+ due to bug" -Warning
+    }
 
     Write-Section -Text "Windows Explorer Tweaks"
     Write-Status -Symbol $EnableStatus[1].Symbol -Type $TweakType -Status "$($EnableStatus[1].Status) Quick Access from Windows Explorer..."

--- a/src/scripts/personal-tweaks.ps1
+++ b/src/scripts/personal-tweaks.ps1
@@ -17,7 +17,6 @@ function Register-PersonalTweaksList() {
         )
     )
     $TweakType = "Personal"
-    $WinVer = (Get-CimInstance -class Win32_OperatingSystem).Caption
 
     If ($Revert) {
         Write-Status -Symbol "<" -Type $TweakType -Status "Reverting the tweaks is set to '$Revert'." -Warning


### PR DESCRIPTION
### Changes on this PR
- Task manager details tweak don't hang anymore on Windows 11 Preview Builds with new Task Manager
- Closes #33

Credits to **ChrisTitusTech**.