### PR TITLE
`refactor`: rename Write-Status function paremeter to receive an array

### DIFF
--- a/Win10ScriptGUI.ps1
+++ b/Win10ScriptGUI.ps1
@@ -8,7 +8,7 @@ function Request-AdminPrivilege() {
 }
 
 function Show-GUI() {
-    Write-Status -Symbol "@" -Status "Loading GUI Layout..."
+    Write-Status -Types "@" -Status "Loading GUI Layout..."
     # Loading System Libs
     Add-Type -AssemblyName System.Windows.Forms
     Add-Type -AssemblyName System.Drawing
@@ -397,17 +397,17 @@ function Show-GUI() {
     $CbDarkTheme.Add_Click( {
             If ($CbDarkTheme.CheckState -eq "Checked") {
                 Open-RegFilesCollection -RelativeLocation "src\utils" -Scripts @("use-dark-theme.reg") -NoDialog
-                $CbDarkTheme.Text = "[ON]  ⚫ Use Dark Theme"
+                $CbDarkTheme.Text = "[ON]  Use Dark Theme"
             } Else {
                 Open-RegFilesCollection -RelativeLocation "src\utils" -Scripts @("use-light-theme.reg") -NoDialog
-                $CbDarkTheme.Text = "[OFF] ☀ Use Dark Theme (D.)"
+                $CbDarkTheme.Text = "[OFF] Use Dark Theme *"
             }
         })
 
     $CbActivityHistory.Add_Click( {
             If ($CbActivityHistory.CheckState -eq "Checked") {
                 Open-RegFilesCollection -RelativeLocation "src\utils" -Scripts @("enable-activity-history.reg") -NoDialog
-                $CbActivityHistory.Text = "[ON]  Activity History (Default)"
+                $CbActivityHistory.Text = "[ON]  Activity History *"
             } Else {
                 Open-RegFilesCollection -RelativeLocation "src\utils" -Scripts @("disable-activity-history.reg") -NoDialog
                 $CbActivityHistory.Text = "[OFF] Activity History"
@@ -417,7 +417,7 @@ function Show-GUI() {
     $CbBackgroundsApps.Add_Click( {
             If ($CbBackgroundsApps.CheckState -eq "Checked") {
                 Open-RegFilesCollection -RelativeLocation "src\utils" -Scripts @("enable-bg-apps.reg") -NoDialog
-                $CbBackgroundsApps.Text = "[ON]  Background Apps (D.)"
+                $CbBackgroundsApps.Text = "[ON]  Background Apps *"
             } Else {
                 Open-RegFilesCollection -RelativeLocation "src\utils" -Scripts @("disable-bg-apps.reg") -NoDialog
                 $CbBackgroundsApps.Text = "[OFF] Background Apps"
@@ -427,7 +427,7 @@ function Show-GUI() {
     $CbClipboardHistory.Add_Click( {
             If ($CbClipboardHistory.CheckState -eq "Checked") {
                 Open-RegFilesCollection -RelativeLocation "src\utils" -Scripts @("enable-clipboard-history.reg") -NoDialog
-                $CbClipboardHistory.Text = "[ON]  Clipboard History (D.)"
+                $CbClipboardHistory.Text = "[ON]  Clipboard History *"
             } Else {
                 Open-RegFilesCollection -RelativeLocation "src\utils" -Scripts @("disable-clipboard-history.reg") -NoDialog
                 $CbClipboardHistory.Text = "[OFF] Clipboard History"
@@ -437,7 +437,7 @@ function Show-GUI() {
     $CbCortana.Add_Click( {
             If ($CbCortana.CheckState -eq "Checked") {
                 Open-RegFilesCollection -RelativeLocation "src\utils" -Scripts @("enable-cortana.reg") -NoDialog
-                $CbCortana.Text = "[ON]  Cortana (Default)"
+                $CbCortana.Text = "[ON]  Cortana *"
             } Else {
                 Open-RegFilesCollection -RelativeLocation "src\utils" -Scripts @("disable-cortana.reg") -NoDialog
                 $CbCortana.Text = "[OFF] Cortana"
@@ -450,7 +450,7 @@ function Show-GUI() {
                 $CbOldVolumeControl.Text = "[ON]  Old Volume Control"
             } Else {
                 Open-RegFilesCollection -RelativeLocation "src\utils" -Scripts @("disable-old-volume-control.reg") -NoDialog
-                $CbOldVolumeControl.Text = "[OFF] Old Volume Control (D.)"
+                $CbOldVolumeControl.Text = "[OFF] Old Volume Control *"
             }
         })
 
@@ -460,14 +460,14 @@ function Show-GUI() {
                 $CbPhotoViewer.Text = "[ON]  Photo Viewer"
             } Else {
                 Open-RegFilesCollection -RelativeLocation "src\utils" -Scripts @("disable-photo-viewer.reg") -NoDialog
-                $CbPhotoViewer.Text = "[OFF] Photo Viewer (D.)"
+                $CbPhotoViewer.Text = "[OFF] Photo Viewer *"
             }
         })
 
     $CbSearchIdx.Add_Click( {
             If ($CbSearchIdx.CheckState -eq "Checked") {
                 Open-PowerShellFilesCollection -RelativeLocation "src\utils" -Scripts @("enable-search-idx-service.ps1") -NoDialog
-                $CbSearchIdx.Text = "[ON]  Search Indexing (Default)"
+                $CbSearchIdx.Text = "[ON]  Search Indexing *"
             } Else {
                 Open-PowerShellFilesCollection -RelativeLocation "src\utils" -Scripts @("disable-search-idx-service.ps1") -NoDialog
                 $CbSearchIdx.Text = "[OFF] Search Indexing"
@@ -477,7 +477,7 @@ function Show-GUI() {
     $CbTelemetry.Add_Click( {
             If ($CbTelemetry.CheckState -eq "Checked") {
                 Open-RegFilesCollection -RelativeLocation "src\utils" -Scripts @("enable-telemetry.reg") -NoDialog
-                $CbTelemetry.Text = "[ON]  Telemetry (Default)"
+                $CbTelemetry.Text = "[ON]  Telemetry *"
             } Else {
                 Open-RegFilesCollection -RelativeLocation "src\utils" -Scripts @("disable-telemetry.reg") -NoDialog
                 $CbTelemetry.Text = "[OFF] Telemetry"
@@ -487,7 +487,7 @@ function Show-GUI() {
     $CbXboxGameBarAndDVR.Add_Click( {
             If ($CbXboxGameBarAndDVR.CheckState -eq "Checked") {
                 Open-RegFilesCollection -RelativeLocation "src\utils" -Scripts @("enable-game-bar-dvr.reg") -NoDialog
-                $CbXboxGameBarAndDVR.Text = "[ON]  Xbox GameBar/DVR (D.)"
+                $CbXboxGameBarAndDVR.Text = "[ON]  Xbox GameBar/DVR *"
             } Else {
                 Open-RegFilesCollection -RelativeLocation "src\utils" -Scripts @("disable-game-bar-dvr.reg") -NoDialog
                 $CbXboxGameBarAndDVR.Text = "[OFF] Xbox GameBar/DVR"
@@ -500,7 +500,7 @@ function Show-GUI() {
                 $CbGodMode.Text = "[ON]  God Mode"
             } Else {
                 Open-PowerShellFilesCollection -RelativeLocation "src\utils" -Scripts @("disable-god-mode.ps1") -NoDialog
-                $CbGodMode.Text = "[OFF] God Mode (Default)"
+                $CbGodMode.Text = "[OFF] God Mode *"
             }
         })
 
@@ -510,7 +510,7 @@ function Show-GUI() {
                 $CbTakeOwnership.Text = "[ON]  Take Ownership menu"
             } Else {
                 Open-RegFilesCollection -RelativeLocation "src\utils" -Scripts @("disable-take-ownership-context-menu.reg") -NoDialog
-                $CbTakeOwnership.Text = "[OFF] Take Ownership... (D.)"
+                $CbTakeOwnership.Text = "[OFF] Take Ownership... *"
             }
         })
 
@@ -520,7 +520,7 @@ function Show-GUI() {
                 $CbShutdownPCShortcut.Text = "[ON]  Shutdown PC shortcut"
             } Else {
                 Open-PowerShellFilesCollection -RelativeLocation "src\utils" -Scripts @("disable-shutdown-pc-shortcut.ps1") -NoDialog
-                $CbShutdownPCShortcut.Text = "[OFF] Shutdown PC... (Default)"
+                $CbShutdownPCShortcut.Text = "[OFF] Shutdown PC... *"
             }
         })
 

--- a/src/lib/download-web-file.psm1
+++ b/src/lib/download-web-file.psm1
@@ -12,7 +12,7 @@ function Request-FileDownload {
 
     Write-Verbose "[?] I'm at: $PWD"
     If (!(Test-Path "$PSScriptRoot\..\tmp")) {
-        Write-Status -Symbol "@" -Status "$PSScriptRoot\..\tmp doesn't exist, creating folder..."
+        Write-Status -Types "@" -Status "$PSScriptRoot\..\tmp doesn't exist, creating folder..."
         mkdir "$PSScriptRoot\..\tmp" | Out-Null
     }
 
@@ -20,7 +20,7 @@ function Request-FileDownload {
 
     If ($OutputFolder) {
         If (!(Test-Path "$PSScriptRoot\..\tmp\$OutputFolder")) {
-            Write-Status -Symbol "@" -Status "$PSScriptRoot\..\tmp\$OutputFolder doesn't exist, creating folder..."
+            Write-Status -Types "@" -Status "$PSScriptRoot\..\tmp\$OutputFolder doesn't exist, creating folder..."
             mkdir "$PSScriptRoot\..\tmp\$OutputFolder"
         }
         $FileLocation = "$PSScriptRoot\..\tmp\$OutputFolder\$OutputFile"
@@ -28,8 +28,8 @@ function Request-FileDownload {
 
     Import-Module BitsTransfer
     Write-Host
-    Write-Status -Symbol "@" -Status "Downloading from: '$FileURI' as '$OutputFile'"
-    Write-Status -Symbol "@" -Status "On: '$FileLocation'"
+    Write-Status -Types "@" -Status "Downloading from: '$FileURI' as '$OutputFile'"
+    Write-Status -Types "@" -Status "On: '$FileLocation'"
     Start-BitsTransfer -Dynamic -RetryTimeout 60 -TransferType Download -Source $FileURI -Destination $FileLocation
 
     return $FileLocation

--- a/src/lib/get-hardware-info.psm1
+++ b/src/lib/get-hardware-info.psm1
@@ -108,7 +108,7 @@ function Get-SystemSpec() {
         [String] $Separator = '|'
     )
 
-    Write-Status -Symbol "@" -Status "Loading system specs..."
+    Write-Status -Types "@" -Status "Loading system specs..."
     # Adapted From: https://www.delftstack.com/howto/powershell/find-windows-version-in-powershell/#using-the-wmi-class-with-get-wmiobject-cmdlet-in-powershell-to-get-the-windows-version
     $WinVer = (Get-CimInstance -class Win32_OperatingSystem).Caption -replace 'Microsoft ', ''
     $DisplayVersion = (Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion").DisplayVersion

--- a/src/lib/install-font.psm1
+++ b/src/lib/install-font.psm1
@@ -14,7 +14,7 @@ function Install-Font() {
     ForEach ($FontFile in Get-ChildItem $FontSourceFolder -Include '*.ttf', '*.ttc', '*.otf' -Recurse) {
         $TargetPath = Join-Path $SystemFontsPath $FontFile.Name
 
-        Write-Status -Symbol "+" -Status "Installing '$($FontFile.Name)' Font on $TargetPath ..."
+        Write-Status -Types "+" -Status "Installing '$($FontFile.Name)' Font on $TargetPath ..."
 
         Try {
             # Extract Font information for Reqistry
@@ -27,7 +27,7 @@ function Install-Font() {
             $RegName = $ShellFolder.GetDetailsOf($ShellFile, 21) + ' ' + $FontType
         } Catch {
             # This may not be the better way, but this workaround worked
-            Write-Status -Symbol "@" -Status "Got an error, the font type is OpenType" -Warning
+            Write-Status -Types "@" -Status "Got an error, the font type is OpenType" -Warning
             $FontType = '(OpenType)'
             $RegName = ""
             $NameHelper = $FontFile.Name.Replace("-", " ").Replace("_", " ").Replace(".ttf", "").Replace(".ttc", "").Replace(".otf", "").Trim(" ")
@@ -43,7 +43,7 @@ function Install-Font() {
             }
         }
 
-        Write-Status -Symbol "+" -Status "Creating new Registry to $RegName on: $PathToLMWindowsFonts"
+        Write-Status -Types "+" -Status "Creating new Registry to $RegName on: $PathToLMWindowsFonts"
         New-ItemProperty -Path "$PathToLMWindowsFonts" -Name $RegName -PropertyType String -Value $FontFile.Name -Force
         Copy-item $FontFile.FullName -Destination $SystemFontsPath
         Remove-Item $FontFile.FullName

--- a/src/lib/manage-software.psm1
+++ b/src/lib/manage-software.psm1
@@ -24,7 +24,7 @@ function Install-Software() {
         $ViaMSStore, $ViaWSL = $false, $false
         $PkgMngr = 'Chocolatey'
         $InstallBlock = { choco install --ignore-dependencies --yes $Package }
-        Write-Status -Symbol "?" -Status "Chocolatey is configured to ignore dependencies (bloat), you may need to install it before using any program." -Warning
+        Write-Status -Types "?" -Status "Chocolatey is configured to ignore dependencies (bloat), you may need to install it before using any program." -Warning
     }
 
     If ($ViaMSStore) {
@@ -86,7 +86,7 @@ function Uninstall-Software() {
         $ViaMSStore, $ViaWSL = $false, $false
         $PkgMngr = 'Chocolatey'
         $UninstallBlock = { choco uninstall --remove-dependencies --yes $Package }
-        Write-Status -Symbol "?" -Status "Chocolatey is configured to remove dependencies (bloat), you may need to install it before using any program." -Warning
+        Write-Status -Types "?" -Status "Chocolatey is configured to remove dependencies (bloat), you may need to install it before using any program." -Warning
     }
 
     If ($ViaMSStore) {

--- a/src/lib/new-shortcut.psm1
+++ b/src/lib/new-shortcut.psm1
@@ -19,7 +19,7 @@ function New-Shortcut() {
     )
 
     If (!(Test-Path -Path (Split-Path -Path $ShortcutPath))) {
-        Write-Status -Symbol "?" -Status "$((Split-Path -Path $ShortcutPath)) does not exist, creating it..."
+        Write-Status -Types "?" -Status "$((Split-Path -Path $ShortcutPath)) does not exist, creating it..."
         New-Item -Path (Split-Path -Path $ShortcutPath) -ItemType Directory -Force
     }
 

--- a/src/lib/remove-uwp-appx.psm1
+++ b/src/lib/remove-uwp-appx.psm1
@@ -9,11 +9,11 @@ function Remove-UWPAppx() {
 
     ForEach ($AppxPackage in $AppxPackages) {
         If ((Get-AppxPackage -AllUsers -Name $AppxPackage) -or (Get-AppxProvisionedPackage -Online | Where-Object DisplayName -like $AppxPackage)) {
-            Write-Status -Symbol "-" -Type $TweakType -Status "Trying to remove $AppxPackage from ALL users ..."
+            Write-Status -Types "-", $TweakType -Status "Trying to remove $AppxPackage from ALL users ..."
             Get-AppxPackage -AllUsers -Name $AppxPackage | Remove-AppxPackage # App
             Get-AppxProvisionedPackage -Online | Where-Object DisplayName -like $AppxPackage | Remove-AppxProvisionedPackage -Online -AllUsers # Payload
         } Else {
-            Write-Status -Symbol "?" -Type $TweakType -Status "$AppxPackage was already removed or not found ..." -Warning
+            Write-Status -Types "?", $TweakType -Status "$AppxPackage was already removed or not found ..." -Warning
         }
     }
 }

--- a/src/lib/set-scheduled-task-state.psm1
+++ b/src/lib/set-scheduled-task-state.psm1
@@ -11,7 +11,7 @@ function Find-ScheduledTask() {
     If (Get-ScheduledTaskInfo -TaskName $ScheduledTask -ErrorAction SilentlyContinue) {
         return $true
     } Else {
-        Write-Status -Symbol "?" -Type $TweakType -Status "The $ScheduledTask task was not found." -Warning
+        Write-Status -Types "?", $TweakType -Status "The $ScheduledTask task was not found." -Warning
         return $false
     }
 }
@@ -36,20 +36,20 @@ function Set-ScheduledTaskState() {
     ForEach ($ScheduledTask in $ScheduledTasks) {
         If (Find-ScheduledTask $ScheduledTask) {
             If ($ScheduledTask -in $Filter) {
-                Write-Status -Symbol "?" -Type $TweakType -Status "The $ScheduledTask ($((Get-ScheduledTask $ScheduledTask).TaskName)) will be skipped as set on Filter ..." -Warning
+                Write-Status -Types "?", $TweakType -Status "The $ScheduledTask ($((Get-ScheduledTask $ScheduledTask).TaskName)) will be skipped as set on Filter ..." -Warning
                 Continue
             }
 
             If (!$CustomMessage) {
                 If ($Disabled) {
-                    Write-Status -Symbol "-" -Type $TweakType -Status "Disabling the $ScheduledTask task ..."
+                    Write-Status -Types "-", $TweakType -Status "Disabling the $ScheduledTask task ..."
                 } ElseIf ($Ready) {
-                    Write-Status -Symbol "+" -Type $TweakType -Status "Enabling the $ScheduledTask task ..."
+                    Write-Status -Types "+", $TweakType -Status "Enabling the $ScheduledTask task ..."
                 } Else {
-                    Write-Status -Symbol "?" -Type $TweakType -Status "No parameter received (valid params: -Disabled or -Ready)" -Warning
+                    Write-Status -Types "?", $TweakType -Status "No parameter received (valid params: -Disabled or -Ready)" -Warning
                 }
             } Else {
-                Write-Status -Symbol "@" -Type $TweakType -Status $(Invoke-Expression "$CustomMessage")
+                Write-Status -Types "@", $TweakType -Status $(Invoke-Expression "$CustomMessage")
             }
 
             If ($Disabled) {

--- a/src/lib/set-service-startup.psm1
+++ b/src/lib/set-service-startup.psm1
@@ -11,7 +11,7 @@ function Find-Service() {
     If (Get-Service $Service -ErrorAction SilentlyContinue) {
         return $true
     } Else {
-        Write-Status -Symbol "?" -Type $TweakType -Status "The $Service service was not found ..." -Warning
+        Write-Status -Types "?", $TweakType -Status "The $Service service was not found ..." -Warning
         return $false
     }
 }
@@ -39,27 +39,27 @@ function Set-ServiceStartup() {
     ForEach ($Service in $Services) {
         If (Find-Service $Service) {
             If (($Service -in $SecurityFilterOnEnable) -and (($Automatic) -or ($Manual))) {
-                Write-Status -Symbol "?" -Type $TweakType -Status "Skipping $Service ($((Get-Service $Service).DisplayName)) to avoid a security vulnerability ..." -Warning
+                Write-Status -Types "?", $TweakType -Status "Skipping $Service ($((Get-Service $Service).DisplayName)) to avoid a security vulnerability ..." -Warning
                 Continue
             }
 
             If ($Service -in $Filter) {
-                Write-Status -Symbol "?" -Type $TweakType -Status "The $Service ($((Get-Service $Service).DisplayName)) will be skipped as set on Filter ..." -Warning
+                Write-Status -Types "?", $TweakType -Status "The $Service ($((Get-Service $Service).DisplayName)) will be skipped as set on Filter ..." -Warning
                 Continue
             }
 
             If (!$CustomMessage) {
                 If ($Automatic) {
-                    Write-Status -Symbol "+" -Type $TweakType -Status "Setting $Service ($((Get-Service $Service).DisplayName)) as 'Automatic' on Startup ..."
+                    Write-Status -Types "+", $TweakType -Status "Setting $Service ($((Get-Service $Service).DisplayName)) as 'Automatic' on Startup ..."
                 } ElseIf ($Disabled) {
-                    Write-Status -Symbol "-" -Type $TweakType -Status "Setting $Service ($((Get-Service $Service).DisplayName)) as 'Disabled' on Startup ..."
+                    Write-Status -Types "-", $TweakType -Status "Setting $Service ($((Get-Service $Service).DisplayName)) as 'Disabled' on Startup ..."
                 } ElseIf ($Manual) {
-                    Write-Status -Symbol "-" -Type $TweakType -Status "Setting $Service ($((Get-Service $Service).DisplayName)) as 'Manual' on Startup ..."
+                    Write-Status -Types "-", $TweakType -Status "Setting $Service ($((Get-Service $Service).DisplayName)) as 'Manual' on Startup ..."
                 } Else {
-                    Write-Status -Symbol "?" -Type $TweakType -Status "No parameter received (valid params: -Automatic, -Disabled or -Manual)" -Warning
+                    Write-Status -Types "?", $TweakType -Status "No parameter received (valid params: -Automatic, -Disabled or -Manual)" -Warning
                 }
             } Else {
-                Write-Status -Symbol "@" -Type $TweakType -Status $(Invoke-Expression "$CustomMessage")
+                Write-Status -Types "@", $TweakType -Status $(Invoke-Expression "$CustomMessage")
             }
 
             If ($Automatic) {

--- a/src/lib/set-windows-feature-state.psm1
+++ b/src/lib/set-windows-feature-state.psm1
@@ -11,7 +11,7 @@ function Find-OptionalFeature() {
     If (Get-WindowsOptionalFeature -Online -FeatureName $OptionalFeature) {
         return $true
     } Else {
-        Write-Status -Symbol "?" -Type $TweakType -Status "The $OptionalFeature optional feature was not found." -Warning
+        Write-Status -Types "?", $TweakType -Status "The $OptionalFeature optional feature was not found." -Warning
         return $false
     }
 }
@@ -37,25 +37,25 @@ function Set-OptionalFeatureState() {
     ForEach ($OptionalFeature in $OptionalFeatures) {
         If (Find-OptionalFeature $OptionalFeature) {
             If (($OptionalFeature -in $SecurityFilterOnEnable) -and ($Enabled)) {
-                Write-Status -Symbol "?" -Type $TweakType -Status "Skipping $OptionalFeature to avoid a security vulnerability ..." -Warning
+                Write-Status -Types "?", $TweakType -Status "Skipping $OptionalFeature to avoid a security vulnerability ..." -Warning
                 Continue
             }
 
             If ($OptionalFeature -in $Filter) {
-                Write-Status -Symbol "?" -Type $TweakType -Status "The $OptionalFeature will be skipped as set on Filter ..." -Warning
+                Write-Status -Types "?", $TweakType -Status "The $OptionalFeature will be skipped as set on Filter ..." -Warning
                 Continue
             }
 
             If (!$CustomMessage) {
                 If ($Disabled) {
-                    Write-Status -Symbol "-" -Type $TweakType -Status "Uninstalling the $OptionalFeature optional feature ..."
+                    Write-Status -Types "-", $TweakType -Status "Uninstalling the $OptionalFeature optional feature ..."
                 } ElseIf ($Enabled) {
-                    Write-Status -Symbol "+" -Type $TweakType -Status "Installing the $OptionalFeature optional feature ..."
+                    Write-Status -Types "+", $TweakType -Status "Installing the $OptionalFeature optional feature ..."
                 } Else {
-                    Write-Status -Symbol "?" -Type $TweakType -Status "No parameter received (valid params: -Disabled or -Enabled)" -Warning
+                    Write-Status -Types "?", $TweakType -Status "No parameter received (valid params: -Disabled or -Enabled)" -Warning
                 }
             } Else {
-                Write-Status -Symbol "@" -Type $TweakType -Status $(Invoke-Expression "$CustomMessage")
+                Write-Status -Types "@", $TweakType -Status $(Invoke-Expression "$CustomMessage")
             }
 
             If ($Disabled) {

--- a/src/lib/title-templates.psm1
+++ b/src/lib/title-templates.psm1
@@ -33,21 +33,19 @@ function Write-Caption() {
 function Write-Status() {
     [CmdletBinding()]
     param (
-        [String] $Symbol = "No Symbol",
-        [Parameter(Mandatory = $false)]
-        [String] $Type,
-        [String] $Status = "No Text",
+        [Parameter(Mandatory)]
+        [Array]  $Types,
+        [Parameter(Mandatory)]
+        [String] $Status,
         [Switch] $Warning
     )
 
-    Write-Host "[" -NoNewline -ForegroundColor Blue -BackgroundColor Black
-    Write-Host "$Symbol" -NoNewline -ForegroundColor White -BackgroundColor Black
-    Write-Host "] " -NoNewline -ForegroundColor Blue -BackgroundColor Black
-    If ($Type) {
+    ForEach ($Type in $Types) {
         Write-Host "[" -NoNewline -ForegroundColor Blue -BackgroundColor Black
         Write-Host "$Type" -NoNewline -ForegroundColor White -BackgroundColor Black
         Write-Host "] " -NoNewline -ForegroundColor Blue -BackgroundColor Black
     }
+
     If ($Warning) {
         Write-Host "$Status" -ForegroundColor Yellow -BackgroundColor Black
     } Else {
@@ -103,7 +101,8 @@ Example:
 Write-Title -Text "Text" # Used to print Tweak introduction
 Write-Section -Text "Text" # Used to print Tweak Section
 Write-Caption -Text "Text" # Used to print Tweak Category
-Write-Status -Symbol "?" [-Type ""] -Status "Doing something"
+Write-Status -Types "?", ... -Status "Doing something"
+Write-Status -Types "?", ... -Status "Doing something" -Warning
 $Private:Counter = Write-TitleCounter -Text "Text" -Counter $Counter -MaxLenght 100 # Used to print when working with collections # No need to iterate $Counter before, as long it's private
 $Private:Counter = Write-TitleCounter -Text "Text" -Counter $Counter -MaxLenght 100 # Used to print when working with collections # No need to iterate $Counter before, as long it's private
 Write-ScriptLogo # Used at the start of the Script

--- a/src/scripts/backup-system.ps1
+++ b/src/scripts/backup-system.ps1
@@ -1,7 +1,7 @@
 Import-Module -DisableNameChecking $PSScriptRoot\..\lib\"title-templates.psm1"
 
 function New-RestorePoint() {
-    Write-Status -Symbol "+" -Type $TweakType -Status "Enabling system drive Restore Point..."
+    Write-Status -Types "+", $TweakType -Status "Enabling system drive Restore Point..."
     Enable-ComputerRestore -Drive "$env:SystemDrive\"
     Checkpoint-Computer -Description "Win 10+ SDT Restore Point" -RestorePointType "MODIFY_SETTINGS"
 }
@@ -9,12 +9,12 @@ function New-RestorePoint() {
 function Backup-HostsFile() {
     $PathToHostsFile = "$env:SystemRoot\System32\drivers\etc"
 
-    Write-Status -Symbol "+" -Type $TweakType -Status "Doing Backup on Hosts file..."
+    Write-Status -Types "+", $TweakType -Status "Doing Backup on Hosts file..."
     $Date = Get-Date -Format "yyyy-MM-dd_HH-mm-ss"
     Push-Location "$PathToHostsFile"
 
     If (!(Test-Path "$PathToHostsFile\Hosts_Backup")) {
-        Write-Status -Symbol "?" -Type $TweakType -Status "Backup folder not found! Creating a new one..." -ForegroundColor Yellow -BackgroundColor Black
+        Write-Status -Types "?", $TweakType -Status "Backup folder not found! Creating a new one..." -ForegroundColor Yellow -BackgroundColor Black
         mkdir -Path "$PathToHostsFile\Hosts_Backup"
     }
     Push-Location "Hosts_Backup"

--- a/src/scripts/install-package-managers.ps1
+++ b/src/scripts/install-package-managers.ps1
@@ -23,15 +23,15 @@ function Install-PackageManager() {
         $err = $null
         $err = (Invoke-Expression "$CheckExistenceBlock")
         if (($LASTEXITCODE)) { throw $err } # 0 = False, 1 = True
-        Write-Status -Symbol "?" -Status "$PackageManagerFullName is already installed." -Warning
+        Write-Status -Types "?" -Status "$PackageManagerFullName is already installed." -Warning
     } Catch {
-        Write-Status -Symbol "?" -Status "$PackageManagerFullName was not found." -Warning
-        Write-Status -Symbol "+" -Status "Downloading and Installing $PackageManagerFullName package manager."
+        Write-Status -Types "?" -Status "$PackageManagerFullName was not found." -Warning
+        Write-Status -Types "+" -Status "Downloading and Installing $PackageManagerFullName package manager."
 
         Invoke-Expression "$InstallCommandBlock"
 
         If ($PostInstallBlock) {
-            Write-Status -Symbol "+" -Status "Executing post install script: { $("$PostInstallBlock".Trim(' ')) }."
+            Write-Status -Types "+" -Status "Executing post install script: { $("$PostInstallBlock".Trim(' ')) }."
             Invoke-Expression "$PostInstallBlock"
         }
     }
@@ -39,7 +39,7 @@ function Install-PackageManager() {
     # Self-reminder, this part stay out of the Try-Catch block
     If ($UpdateScriptBlock) {
         # Adapted from: https://blogs.technet.microsoft.com/heyscriptingguy/2013/11/23/using-scheduled-tasks-and-scheduled-jobs-in-powershell/
-        Write-Status -Symbol "@" -Status "Creating a daily task to automatically upgrade $PackageManagerFullName packages at $Time."
+        Write-Status -Types "@" -Status "Creating a daily task to automatically upgrade $PackageManagerFullName packages at $Time."
         $JobName = "$PackageManagerFullName Daily Upgrade"
         $ScheduledJob = @{
             Name               = $JobName
@@ -49,13 +49,13 @@ function Install-PackageManager() {
         }
 
         If (Get-ScheduledJob -Name $JobName -ErrorAction SilentlyContinue) {
-            Write-Status -Symbol "@" -Status "ScheduledJob: $JobName FOUND!"
-            Write-Status -Symbol "@" -Status "Re-Creating with the command:"
+            Write-Status -Types "@" -Status "ScheduledJob: $JobName FOUND!"
+            Write-Status -Types "@" -Status "Re-Creating with the command:"
             Write-Host " { $("$UpdateScriptBlock".Trim(' ')) }`n" -ForegroundColor Cyan
             Unregister-ScheduledJob -Name $JobName
             Register-ScheduledJob @ScheduledJob | Out-Null
         } Else {
-            Write-Status -Symbol "@" -Status "Creating Scheduled Job with the command:"
+            Write-Status -Types "@" -Status "Creating Scheduled Job with the command:"
             Write-Host " { $("$UpdateScriptBlock".Trim(' ')) }`n" -ForegroundColor Cyan
             Register-ScheduledJob @ScheduledJob | Out-Null
         }
@@ -72,7 +72,7 @@ function Install-WingetDependency() {
             Add-AppxPackage -Path $WingetDepOutput
             Remove-Item -Path $WingetDepOutput
         } Else {
-            Write-Status -Symbol "?" -Status "$OSArch is not supported!" -Warning
+            Write-Status -Types "?" -Status "$OSArch is not supported!" -Warning
         }
     }
 }

--- a/src/scripts/optimize-performance.ps1
+++ b/src/scripts/optimize-performance.ps1
@@ -19,7 +19,7 @@ function Optimize-Performance() {
     $TweakType = "Performance"
 
     If (($Revert)) {
-        Write-Status -Symbol "<" -Type $TweakType -Status "Reverting the tweaks is set to '$Revert'." -Warning
+        Write-Status -Types "<", $TweakType -Status "Reverting the tweaks is set to '$Revert'." -Warning
         $Zero = 1
         $One = 0
         $EnableStatus = @(
@@ -46,48 +46,48 @@ function Optimize-Performance() {
     Write-Title -Text "Performance Tweaks"
 
     Write-Section -Text "Gaming"
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) Game Bar & Game DVR..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) Game Bar & Game DVR..."
     $Scripts = @("disable-game-bar-dvr.reg")
     If ($Revert) {
         $Scripts = @("enable-game-bar-dvr.reg")
     }
     Open-RegFilesCollection -RelativeLocation "src\utils" -Scripts $Scripts -NoDialog
 
-    Write-Status -Symbol "=" -Type $TweakType -Status "Enabling game mode..."
+    Write-Status -Types "=", $TweakType -Status "Enabling game mode..."
     Set-ItemProperty -Path "$PathToCUGameBar" -Name "AllowAutoGameMode" -Type DWord -Value 1
     Set-ItemProperty -Path "$PathToCUGameBar" -Name "AutoGameModeEnabled" -Type DWord -Value 1
 
     Write-Section -Text "System"
     Write-Caption -Text "Display"
-    Write-Status -Symbol "+" -Type $TweakType -Status "Enable Hardware Accelerated GPU Scheduling... (Windows 10 20H1+ - Needs Restart)"
+    Write-Status -Types "+", $TweakType -Status "Enable Hardware Accelerated GPU Scheduling... (Windows 10 20H1+ - Needs Restart)"
     Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\GraphicsDrivers" -Name "HwSchMode" -Type DWord -Value 2
 
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) SysMain/Superfetch..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) SysMain/Superfetch..."
     # As SysMain was already disabled on the Services, just need to remove it's key
     # [@] (0 = Disable SysMain, 1 = Enable when program is launched, 2 = Enable on Boot, 3 = Enable on everything)
     Set-ItemProperty -Path "$PathToLMPrefetchParams" -Name "EnableSuperfetch" -Type DWord -Value $Zero
 
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) Remote Assistance..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) Remote Assistance..."
     Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Remote Assistance" -Name "fAllowToGetHelp" -Type DWord -Value $Zero
 
-    Write-Status -Symbol "-" -Type $TweakType -Status "Disabling Ndu High RAM Usage..."
+    Write-Status -Types "-", $TweakType -Status "Disabling Ndu High RAM Usage..."
     # [@] (2 = Enable Ndu, 4 = Disable Ndu)
     Set-ItemProperty -Path "HKLM:\SYSTEM\ControlSet001\Services\Ndu" -Name "Start" -Type DWord -Value 4
 
     # Details: https://www.tenforums.com/tutorials/94628-change-split-threshold-svchost-exe-windows-10-a.html
     # Will reduce Processes number considerably on > 4GB of RAM systems
-    Write-Status -Symbol "+" -Type $TweakType -Status "Setting SVCHost to match RAM size..."
+    Write-Status -Types "+", $TweakType -Status "Setting SVCHost to match RAM size..."
     $RamInKB = (Get-CimInstance -ClassName Win32_PhysicalMemory | Measure-Object -Property Capacity -Sum).Sum / 1KB
     Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control" -Name "SvcHostSplitThresholdInKB" -Type DWord -Value $RamInKB
 
-    Write-Status -Symbol "+" -Type $TweakType -Status "Unlimiting your network bandwidth for all your system..." # Based on this Chris Titus video: https://youtu.be/7u1miYJmJ_4
+    Write-Status -Types "+", $TweakType -Status "Unlimiting your network bandwidth for all your system..." # Based on this Chris Titus video: https://youtu.be/7u1miYJmJ_4
     If (!(Test-Path "$PathToLMPoliciesPsched")) {
         New-Item -Path "$PathToLMPoliciesPsched" -Force | Out-Null
     }
     Set-ItemProperty -Path "$PathToLMPoliciesPsched" -Name "NonBestEffortLimit" -Type DWord -Value 0
     Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile" -Name "NetworkThrottlingIndex" -Type DWord -Value 0xffffffff
 
-    Write-Status -Symbol "=" -Type $TweakType -Status "Enabling Windows Store apps Automatic Updates..."
+    Write-Status -Types "=", $TweakType -Status "Enabling Windows Store apps Automatic Updates..."
     If (!(Test-Path "$PathToLMPoliciesWindowsStore")) {
         New-Item -Path "$PathToLMPoliciesWindowsStore" -Force | Out-Null
     }
@@ -97,13 +97,13 @@ function Optimize-Performance() {
 
     Write-Section -Text "Power Plan Tweaks"
 
-    Write-Status -Symbol "@" -Type $TweakType -Status "Cleaning up duplicated Power plans..."
+    Write-Status -Types "@", $TweakType -Status "Cleaning up duplicated Power plans..."
     ForEach ($PowerCfgString in $ExistingPowerPlans) {
         $PowerPlanGUID = $PowerCfgString.Split(':')[1].Split('(')[0].Trim()
         $PowerPlanName = $PowerCfgString.Split('(')[-1].Replace(')', '').Trim()
 
         If (($PowerPlanGUID -in $BuiltInPowerPlans.Values)) {
-            Write-Status -Symbol "@" -Type $TweakType -Status "The '$PowerPlanName' power plan` is built-in, skipping $PowerPlanGUID ..." -Warning
+            Write-Status -Types "@", $TweakType -Status "The '$PowerPlanName' power plan` is built-in, skipping $PowerPlanGUID ..." -Warning
             Continue
         }
 
@@ -111,30 +111,30 @@ function Optimize-Performance() {
             If (($PowerPlanName -notin $UniquePowerPlans.Keys) -and ($PowerPlanGUID -notin $UniquePowerPlans.Values)) {
                 $UniquePowerPlans.Add($PowerPlanName, $PowerPlanGUID)
             } Else {
-                Write-Status -Symbol "-" -Type $TweakType -Status "Duplicated '$PowerPlanName' power plan found, deleting $PowerPlanGUID ..."
+                Write-Status -Types "-", $TweakType -Status "Duplicated '$PowerPlanName' power plan found, deleting $PowerPlanGUID ..."
                 powercfg -Delete $PowerPlanGUID
             }
         } Catch {
-            Write-Status -Symbol "-" -Type $TweakType -Status "Duplicated '$PowerPlanName' power plan found, deleting $PowerPlanGUID ..."
+            Write-Status -Types "-", $TweakType -Status "Duplicated '$PowerPlanName' power plan found, deleting $PowerPlanGUID ..."
             powercfg -Delete $PowerPlanGUID
         }
     }
 
-    Write-Status -Symbol "+" -Type $TweakType -Status "Setting Power Plan to High Performance..."
+    Write-Status -Types "+", $TweakType -Status "Setting Power Plan to High Performance..."
     powercfg -SetActive 8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c
 
-    Write-Status -Symbol "+" -Type $TweakType -Status "Creating the Ultimate Performance hidden Power Plan..."
+    Write-Status -Types "+", $TweakType -Status "Creating the Ultimate Performance hidden Power Plan..."
     powercfg -DuplicateScheme e9a42b02-d5df-448d-aa00-03f14749eb61
 
-    Write-Status -Symbol "+" -Type $TweakType -Status "Setting Hibernate size to reduced..."
+    Write-Status -Types "+", $TweakType -Status "Setting Hibernate size to reduced..."
     powercfg -Hibernate -type Reduced
 
-    Write-Status -Symbol "+" -Type $TweakType -Status "Enabling Hibernate (Boots faster on Laptops/PCs with HDD and generate '$env:SystemDrive\hiberfil.sys' file)..."
+    Write-Status -Types "+", $TweakType -Status "Enabling Hibernate (Boots faster on Laptops/PCs with HDD and generate '$env:SystemDrive\hiberfil.sys' file)..."
     powercfg -Hibernate on
 
     Write-Section -Text "Network & Internet"
     Write-Caption -Text "Proxy"
-    Write-Status -Symbol "-" -Type $TweakType -Status "Fixing Edge slowdown by NOT Automatically Detecting Settings..."
+    Write-Status -Types "-", $TweakType -Status "Fixing Edge slowdown by NOT Automatically Detecting Settings..."
     # Code from: https://www.reddit.com/r/PowerShell/comments/5iarip/set_proxy_settings_to_automatically_detect/?utm_source=share&utm_medium=web2x&context=3
     $Key = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings\Connections'
     $Data = (Get-ItemProperty -Path $Key -Name DefaultConnectionSettings).DefaultConnectionSettings

--- a/src/scripts/optimize-privacy.ps1
+++ b/src/scripts/optimize-privacy.ps1
@@ -20,7 +20,7 @@ function Optimize-Privacy() {
     $TweakType = "Privacy"
 
     If ($Revert) {
-        Write-Status -Symbol "<" -Type $TweakType -Status "Reverting the tweaks is set to '$Revert'." -Warning
+        Write-Status -Types "<", $TweakType -Status "Reverting the tweaks is set to '$Revert'." -Warning
         $Zero = 1
         $One = 0
         $EnableStatus = @(
@@ -53,8 +53,8 @@ function Optimize-Privacy() {
     Write-Title -Text "Privacy Tweaks"
     Write-Section -Text "Personalization"
     Write-Caption -Text "Start & Lockscreen"
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) Show me the windows welcome experience after updates..."
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) 'Get fun facts and tips, etc. on lock screen'..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) Show me the windows welcome experience after updates..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) 'Get fun facts and tips, etc. on lock screen'..."
 
     $ContentDeliveryManagerDisableOnZero = @(
         "SubscribedContent-310093Enabled"
@@ -80,36 +80,36 @@ function Optimize-Privacy() {
         "SystemPaneSuggestionsEnabled"
     )
 
-    Write-Status -Symbol "?" -Type $TweakType -Status "From Path: [$PathToCUContentDeliveryManager]." -Warning
+    Write-Status -Types "?", $TweakType -Status "From Path: [$PathToCUContentDeliveryManager]." -Warning
     ForEach ($Name in $ContentDeliveryManagerDisableOnZero) {
-        Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) $($Name): $Zero"
+        Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) $($Name): $Zero"
         Set-ItemProperty -Path "$PathToCUContentDeliveryManager" -Name "$Name" -Type DWord -Value $Zero
     }
 
-    Write-Status -Symbol "-" -Type $TweakType -Status "Disabling 'Suggested Content in the Settings App'..."
+    Write-Status -Types "-", $TweakType -Status "Disabling 'Suggested Content in the Settings App'..."
     If (Test-Path "$PathToCUContentDeliveryManager\Subscriptions") {
         Remove-Item -Path "$PathToCUContentDeliveryManager\Subscriptions" -Recurse
     }
 
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) 'Show Suggestions' in Start..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) 'Show Suggestions' in Start..."
     If (Test-Path "$PathToCUContentDeliveryManager\SuggestedApps") {
         Remove-Item -Path "$PathToCUContentDeliveryManager\SuggestedApps" -Recurse
     }
 
     Write-Section -Text "Privacy -> Windows Permissions"
     Write-Caption -Text "General"
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) Let apps use my advertising ID..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) Let apps use my advertising ID..."
     Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\AdvertisingInfo" -Name "Enabled" -Type DWord -Value $Zero
     If (!(Test-Path "$PathToLMPoliciesAdvertisingInfo")) {
         New-Item -Path "$PathToLMPoliciesAdvertisingInfo" -Force | Out-Null
     }
     Set-ItemProperty -Path "$PathToLMPoliciesAdvertisingInfo" -Name "DisabledByGroupPolicy" -Type DWord -Value $One
 
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) 'Let websites provide locally relevant content by accessing my language list'..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) 'Let websites provide locally relevant content by accessing my language list'..."
     Set-ItemProperty -Path "HKCU:\Control Panel\International\User Profile" -Name "HttpAcceptLanguageOptOut" -Type DWord -Value $One
 
     Write-Caption -Text "Speech"
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) Online Speech Recognition..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) Online Speech Recognition..."
     If (!(Test-Path "$PathToCUOnlineSpeech")) {
         New-Item -Path "$PathToCUOnlineSpeech" -Force | Out-Null
     }
@@ -123,25 +123,25 @@ function Optimize-Privacy() {
     Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Personalization\Settings" -Name "AcceptedPrivacyPolicy" -Type DWord -Value $Zero
 
     Write-Caption -Text "Diagnostics & Feedback"
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) telemetry..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) telemetry..."
     # [@] (0 = Security (Enterprise only), 1 = Basic Telemetry, 2 = Enhanced Telemetry, 3 = Full Telemetry)
     Set-ItemProperty -Path "$PathToLMPoliciesTelemetry" -Name "AllowTelemetry" -Type DWord -Value $Zero
     Set-ItemProperty -Path "$PathToLMPoliciesTelemetry2" -Name "AllowTelemetry" -Type DWord -Value $Zero
     Set-ItemProperty -Path "$PathToLMPoliciesTelemetry" -Name "AllowDeviceNameInTelemetry" -Type DWord -Value $Zero
 
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) send inking and typing data to Microsoft..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) send inking and typing data to Microsoft..."
     If (!(Test-Path "$PathToCUInputTIPC")) {
         New-Item -Path "$PathToCUInputTIPC" -Force | Out-Null
     }
     Set-ItemProperty -Path "$PathToCUInputTIPC" -Name "Enabled" -Type DWord -Value $Zero
 
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) Tailored Experiences..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) Tailored Experiences..."
     Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Privacy" -Name "TailoredExperiencesWithDiagnosticDataEnabled" -Type DWord -Value $Zero
 
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) View diagnostic data..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) View diagnostic data..."
     Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Diagnostics\DiagTrack\EventTranscriptKey" -Name "EnableEventTranscript" -Type DWord -Value $Zero
 
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) feedback frequency..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) feedback frequency..."
     If (!(Test-Path "$PathToCUSiufRules")) {
         New-Item -Path "$PathToCUSiufRules" -Force | Out-Null
     }
@@ -151,16 +151,16 @@ function Optimize-Privacy() {
     Set-ItemProperty -Path "$PathToCUSiufRules" -Name "NumberOfSIUFInPeriod" -Type DWord -Value $Zero
 
     Write-Caption -Text "Activity History"
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) Activity History..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) Activity History..."
     $ActivityHistoryDisableOnZero = @(
         "EnableActivityFeed"
         "PublishUserActivities"
         "UploadUserActivities"
     )
 
-    Write-Status -Symbol "?" -Type $TweakType -Status "From Path: [$PathToLMActivityHistory]" -Warning
+    Write-Status -Types "?", $TweakType -Status "From Path: [$PathToLMActivityHistory]" -Warning
     ForEach ($Name in $ActivityHistoryDisableOnZero) {
-        Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) $($Name): $Zero"
+        Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) $($Name): $Zero"
         Set-ItemProperty -Path "$PathToLMActivityHistory" -Name "$ActivityHistoryDisableOnZero" -Type DWord -Value $Zero
     }
 
@@ -183,7 +183,7 @@ function Optimize-Privacy() {
     Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\userAccountInformation" -Name "Value" -Value "Deny"
 
     Write-Caption -Text "Other Devices"
-    Write-Status -Symbol "-" -Type $TweakType -Status "Denying device access..."
+    Write-Status -Types "-", $TweakType -Status "Denying device access..."
     If (!(Test-Path "$PathToCUDeviceAccessGlobal\LooselyCoupled")) {
         New-Item -Path "$PathToCUDeviceAccessGlobal\LooselyCoupled" -Force | Out-Null
     }
@@ -193,18 +193,18 @@ function Optimize-Privacy() {
         If ($key.PSChildName -EQ "LooselyCoupled") {
             continue
         }
-        Write-Status -Symbol $EnableStatus[1].Symbol -Type $TweakType -Status "$($EnableStatus[1].Status) Setting $($key.PSChildName) value to 'Deny' ..."
+        Write-Status -Types $EnableStatus[1].Symbol, $TweakType -Status "$($EnableStatus[1].Status) Setting $($key.PSChildName) value to 'Deny' ..."
         Set-ItemProperty -Path ("$PathToCUDeviceAccessGlobal\" + $key.PSChildName) -Name "Value" -Value "Deny"
     }
 
     Write-Caption -Text "Background Apps"
-    Write-Status -Symbol $EnableStatus[1].Symbol -Type $TweakType -Status "$($EnableStatus[1].Status) Background Apps..."
+    Write-Status -Types $EnableStatus[1].Symbol, $TweakType -Status "$($EnableStatus[1].Status) Background Apps..."
     Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications" -Name "GlobalUserDisabled" -Type DWord -Value 0
     Set-ItemProperty -Path "$PathToCUSearch" -Name "BackgroundAppGlobalToggle" -Type DWord -Value 1
 
     Write-Section -Text "Update & Security"
     Write-Caption -Text "Windows Update"
-    Write-Status -Symbol "-" -Type $TweakType -Status "Disabling Automatic Download and Installation of Windows Updates..."
+    Write-Status -Types "-", $TweakType -Status "Disabling Automatic Download and Installation of Windows Updates..."
     If (!(Test-Path "$PathToLMPoliciesWindowsUpdate")) {
         New-Item -Path "$PathToLMPoliciesWindowsUpdate" -Force | Out-Null
     }
@@ -212,26 +212,26 @@ function Optimize-Privacy() {
     # [@] (4 = Automatically download and schedule installation, 5 = Automatic Updates is required and users can configure it)
     Set-ItemProperty -Path "$PathToLMPoliciesWindowsUpdate" -Name "AUOptions" -Type DWord -Value 2
 
-    Write-Status -Symbol $EnableStatus[1].Symbol -Type $TweakType -Status "$($EnableStatus[1].Status) Automatic Updates..."
+    Write-Status -Types $EnableStatus[1].Symbol, $TweakType -Status "$($EnableStatus[1].Status) Automatic Updates..."
     # [@] (0 = Enable Automatic Updates, 1 = Disable Automatic Updates)
     Set-ItemProperty -Path "$PathToLMPoliciesWindowsUpdate" -Name "NoAutoUpdate" -Type DWord -Value $Zero
 
-    Write-Status -Symbol "+" -Type $TweakType -Status "Setting Scheduled Day to Every day..."
+    Write-Status -Types "+", $TweakType -Status "Setting Scheduled Day to Every day..."
     # [@] (0 = Every day, 1~7 = The days of the week from Sunday (1) to Saturday (7) (Only valid if AUOptions = 4))
     Set-ItemProperty -Path "$PathToLMPoliciesWindowsUpdate" -Name "ScheduledInstallDay" -Type DWord -Value 0
 
-    Write-Status -Symbol "-" -Type $TweakType -Status "Setting Scheduled time to 03h00m..."
+    Write-Status -Types "-", $TweakType -Status "Setting Scheduled time to 03h00m..."
     # [@] (0-23 = The time of day in 24-hour format)
     Set-ItemProperty -Path "$PathToLMPoliciesWindowsUpdate" -Name "ScheduledInstallTime" -Type DWord -Value 3
 
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) Automatic Reboot after update..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) Automatic Reboot after update..."
     # [@] (0 = Enable Automatic Reboot after update, 1 = Disable Automatic Reboot after update)
     Set-ItemProperty -Path "$PathToLMPoliciesWindowsUpdate" -Name "NoAutoRebootWithLoggedOnUsers" -Type DWord -Value $One
 
-    Write-Status -Symbol $EnableStatus[1].Symbol -Type $TweakType -Status "$($EnableStatus[1].Status) Change Windows Updates to 'Notify to schedule restart'..."
+    Write-Status -Types $EnableStatus[1].Symbol, $TweakType -Status "$($EnableStatus[1].Status) Change Windows Updates to 'Notify to schedule restart'..."
     Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\WindowsUpdate\UX\Settings" -Name "UxOption" -Type DWord -Value $One
 
-    Write-Status -Symbol $EnableStatus[1].Symbol -Type $TweakType -Status "$($EnableStatus[1].Status) Restricting Windows Update P2P downloads for Local Network only..."
+    Write-Status -Types $EnableStatus[1].Symbol, $TweakType -Status "$($EnableStatus[1].Status) Restricting Windows Update P2P downloads for Local Network only..."
     If (!(Test-Path "$PathToLMDeliveryOptimizationCfg")) {
         New-Item -Path "$PathToLMDeliveryOptimizationCfg" -Force | Out-Null
     }
@@ -240,15 +240,15 @@ function Optimize-Privacy() {
     Set-ItemProperty -Path "$PathToLMDeliveryOptimizationCfg" -Name "DODownloadMode" -Type DWord -Value $One
 
     Write-Caption -Text "Troubleshooting"
-    Write-Status -Symbol "+" -Type $TweakType -Status "Enabling Automatic Recommended Troubleshooting, then notify me..."
+    Write-Status -Types "+", $TweakType -Status "Enabling Automatic Recommended Troubleshooting, then notify me..."
     If (!(Test-Path "$PathToLMWindowsTroubleshoot")) {
         New-Item -Path "$PathToLMWindowsTroubleshoot" -Force | Out-Null
     }
     Set-ItemProperty -Path "$PathToLMWindowsTroubleshoot" -Name "UserPreference" -Type DWord -Value 3
 
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) Windows Spotlight Features..."
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) Third Party Suggestions..."
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) More Telemetry Features..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) Windows Spotlight Features..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) Third Party Suggestions..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) More Telemetry Features..."
 
     $CloudContentDisableOnOne = @(
         "DisableWindowsSpotlightFeatures"
@@ -259,9 +259,9 @@ function Optimize-Privacy() {
         "DisableThirdPartySuggestions"
     )
 
-    Write-Status -Symbol "?" -Type $TweakType -Status "From Path: [$PathToCUPoliciesCloudContent]." -Warning
+    Write-Status -Types "?", $TweakType -Status "From Path: [$PathToCUPoliciesCloudContent]." -Warning
     ForEach ($Name in $CloudContentDisableOnOne) {
-        Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) $($Name): $One"
+        Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) $($Name): $One"
         Set-ItemProperty -Path "$PathToCUPoliciesCloudContent" -Name "$Name" -Type DWord -Value $One
     }
     If (!(Test-Path "$PathToCUPoliciesCloudContent")) {
@@ -270,7 +270,7 @@ function Optimize-Privacy() {
     Set-ItemProperty -Path "$PathToCUPoliciesCloudContent" -Name "ConfigureWindowsSpotlight" -Type DWord -Value 2
     Set-ItemProperty -Path "$PathToCUPoliciesCloudContent" -Name "IncludeEnterpriseSpotlight" -Type DWord -Value $Zero
 
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) Apps Suggestions..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) Apps Suggestions..."
     If (!(Test-Path "$PathToLMPoliciesCloudContent")) {
         New-Item -Path "$PathToLMPoliciesCloudContent" -Force | Out-Null
     }
@@ -278,7 +278,7 @@ function Optimize-Privacy() {
     Set-ItemProperty -Path "$PathToLMPoliciesCloudContent" -Name "DisableWindowsConsumerFeatures" -Type DWord -Value $One
 
     # Reference: https://forums.guru3d.com/threads/windows-10-registry-tweak-for-disabling-drivers-auto-update-controversy.418033/
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) automatic driver updates..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) automatic driver updates..."
     # [@] (0 = Yes, do this automatically, 1 = No, let me choose what to do, Always install the best, 2 = [...] Install driver software from Windows Update, 3 = [...] Never install driver software from Windows Update
     Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Device Metadata" -Name "PreventDeviceMetadataFromNetwork" -Type DWord -Value $One
     # [@] (0 = Enhanced icons enabled, 1 = Enhanced icons disabled)
@@ -292,20 +292,20 @@ function Optimize-Privacy() {
     Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\AppCompat" -Name "DisableUAR" -Type DWord -Value $One
 
     # Details: https://docs.microsoft.com/pt-br/windows-server/remote/remote-desktop-services/rds-vdi-recommendations-2004#windows-system-startup-event-traces-autologgers
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) some startup event traces (AutoLoggers)..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) some startup event traces (AutoLoggers)..."
     If (!(Test-Path "$PathToLMAutoLogger\AutoLogger-Diagtrack-Listener")) {
         New-Item -Path "$PathToLMAutoLogger\AutoLogger-Diagtrack-Listener" -Force | Out-Null
     }
     Set-ItemProperty -Path "$PathToLMAutoLogger\AutoLogger-Diagtrack-Listener" -Name "Start" -Type DWord -Value $Zero
     Set-ItemProperty -Path "$PathToLMAutoLogger\SQMLogger" -Name "Start" -Type DWord -Value $Zero
 
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) 'WiFi Sense: HotSpot Sharing'..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) 'WiFi Sense: HotSpot Sharing'..."
     If (!(Test-Path "$PathToLMPoliciesToWifi\AllowWiFiHotSpotReporting")) {
         New-Item -Path "$PathToLMPoliciesToWifi\AllowWiFiHotSpotReporting" -Force | Out-Null
     }
     Set-ItemProperty -Path "$PathToLMPoliciesToWifi\AllowWiFiHotSpotReporting" -Name "value" -Type DWord -Value $Zero
 
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) 'WiFi Sense: Shared HotSpot Auto-Connect'..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) 'WiFi Sense: Shared HotSpot Auto-Connect'..."
     If (!(Test-Path "$PathToLMPoliciesToWifi\AllowAutoConnectToWiFiSenseHotspots")) {
         New-Item -Path "$PathToLMPoliciesToWifi\AllowAutoConnectToWiFiSenseHotspots" -Force | Out-Null
     }
@@ -341,7 +341,7 @@ function Optimize-Privacy() {
 
     ForEach ($Key in $KeysToDelete) {
         If ((Test-Path $Key)) {
-            Write-Status -Symbol '-' -Type $TweakType -Status "Removing Key: [$Key]"
+            Write-Status -Types "-", $TweakType -Status "Removing Key: [$Key]"
             Remove-Item $Key -Recurse
         }
     }

--- a/src/scripts/optimize-security.ps1
+++ b/src/scripts/optimize-security.ps1
@@ -16,66 +16,66 @@ function Optimize-Security() {
     Write-Title -Text "Security Tweaks"
 
     Write-Section -Text "Windows Firewall"
-    Write-Status -Symbol "+" -Type $TweakType -Status "Enabling default firewall profiles..."
+    Write-Status -Types "+", $TweakType -Status "Enabling default firewall profiles..."
     Set-NetFirewallProfile -Profile Domain, Public, Private -Enabled True
 
     Write-Section -Text "Windows Defender"
-    Write-Status -Symbol "?" -Type $TweakType -Status "If you already use another antivirus, nothing will happen." -Warning
-    Write-Status -Symbol "+" -Type $TweakType -Status "Ensuring your Windows Defender is ENABLED..."
+    Write-Status -Types "?", $TweakType -Status "If you already use another antivirus, nothing will happen." -Warning
+    Write-Status -Types "+", $TweakType -Status "Ensuring your Windows Defender is ENABLED..."
     Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows Defender" -Name "DisableAntiSpyware" -Type DWORD -Value 0 -Force
     Set-MpPreference -DisableRealtimeMonitoring $false -Force
 
-    Write-Status -Symbol "+" -Type $TweakType -Status "Enabling Microsoft Defender Exploit Guard network protection..."
+    Write-Status -Types "+", $TweakType -Status "Enabling Microsoft Defender Exploit Guard network protection..."
     Set-MpPreference -EnableNetworkProtection Enabled -Force
 
-    Write-Status -Symbol "+" -Type $TweakType -Status "Enabling detection for potentially unwanted applications and block them..."
+    Write-Status -Types "+", $TweakType -Status "Enabling detection for potentially unwanted applications and block them..."
     Set-MpPreference -PUAProtection Enabled -Force
 
     Write-Section -Text "SmartScreen"
-    Write-Status -Symbol "+" -Type $TweakType -Status "Enabling 'SmartScreen' for Microsoft Edge..."
+    Write-Status -Types "+", $TweakType -Status "Enabling 'SmartScreen' for Microsoft Edge..."
     If (!(Test-Path "$PathToLMPoliciesEdge\PhishingFilter")) {
         New-Item -Path "$PathToLMPoliciesEdge\PhishingFilter" -Force | Out-Null
     }
     Set-ItemProperty -Path "$PathToLMPoliciesEdge\PhishingFilter" -Name "EnabledV9" -Type DWord -Value 1
 
-    Write-Status -Symbol "+" -Type $TweakType -Status "Enabling 'SmartScreen' for Store Apps..."
+    Write-Status -Types "+", $TweakType -Status "Enabling 'SmartScreen' for Store Apps..."
     Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppHost" -Name "EnableWebContentEvaluation" -Type DWord -Value 1
 
     Write-Section -Text "Old SMB Protocol"
     # Details: https://techcommunity.microsoft.com/t5/storage-at-microsoft/stop-using-smb1/ba-p/425858
-    Write-Status -Symbol "+" -Type $TweakType -Status "Disabling SMB 1.0 protocol..."
+    Write-Status -Types "+", $TweakType -Status "Disabling SMB 1.0 protocol..."
     Set-SmbServerConfiguration -EnableSMB1Protocol $false -Force
 
     Write-Section -Text "Old .NET cryptography"
     # Enable strong cryptography for .NET Framework (version 4 and above) - https://stackoverflow.com/a/47682111
-    Write-Status -Symbol "+" -Type $TweakType -Status "Enabling .NET strong cryptography..."
+    Write-Status -Types "+", $TweakType -Status "Enabling .NET strong cryptography..."
     Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\.NETFramework\v4.0.30319" -Name "SchUseStrongCrypto" -Type DWord -Value 1
     Set-ItemProperty -Path "HKLM:\SOFTWARE\Wow6432Node\Microsoft\.NETFramework\v4.0.30319" -Name "SchUseStrongCrypto" -Type DWord -Value 1
 
     Write-Section -Text "Autoplay and Autorun (Removable Devices)"
-    Write-Status -Symbol "-" -Type $TweakType -Status "Disabling Autoplay..."
+    Write-Status -Types "-", $TweakType -Status "Disabling Autoplay..."
     Set-ItemProperty -Path "$PathToCUExplorer\AutoplayHandlers" -Name "DisableAutoplay" -Type DWord -Value 1
 
-    Write-Status -Symbol "-" -Type $TweakType -Status "Disabling Autorun for all Drives..."
+    Write-Status -Types "-", $TweakType -Status "Disabling Autorun for all Drives..."
     If (!(Test-Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer")) {
         New-Item -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" -Force | Out-Null
     }
     Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" -Name "NoDriveTypeAutoRun" -Type DWord -Value 255
 
     Write-Section -Text "Microsoft Store"
-    Write-Status -Symbol "-" -Type $TweakType -Status "Disabling Search for App in Store for Unknown Extensions..."
+    Write-Status -Types "-", $TweakType -Status "Disabling Search for App in Store for Unknown Extensions..."
     If (!(Test-Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer")) {
         New-Item -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer" -Force | Out-Null
     }
     Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer" -Name "NoUseStoreOpenWith" -Type DWord -Value 1
 
     Write-Section -Text "Windows Explorer"
-    Write-Status -Symbol "+" -Type $TweakType -Status "Enabling Show file extensions in Explorer..."
+    Write-Status -Types "+", $TweakType -Status "Enabling Show file extensions in Explorer..."
     Set-ItemProperty -Path "$PathToCUExplorerAdvanced" -Name "HideFileExt" -Type DWord -Value 0
 
     Write-Section -Text "User Account Control (UAC)"
     # Details: https://docs.microsoft.com/pt-br/windows/security/identity-protection/user-account-control/user-account-control-group-policy-and-registry-key-settings
-    Write-Status -Symbol "+" -Type $TweakType -Status "Raising UAC level..."
+    Write-Status -Types "+", $TweakType -Status "Raising UAC level..."
     If (!(Test-Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System")) {
         New-Item -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" -Force | Out-Null
     }
@@ -84,20 +84,20 @@ function Optimize-Security() {
 
     Write-Section -Text "Windows Update"
     # Details: https://forums.malwarebytes.com/topic/246740-new-potentially-unwanted-modification-disablemrt/
-    Write-Status -Symbol "+" -Type $TweakType -Status "Enabling offer Malicious Software Removal Tool via Windows Update..."
+    Write-Status -Types "+", $TweakType -Status "Enabling offer Malicious Software Removal Tool via Windows Update..."
     If (!(Test-Path "$PathToLMPoliciesMRT")) {
         New-Item -Path "$PathToLMPoliciesMRT" -Force | Out-Null
     }
     Set-ItemProperty -Path "$PathToLMPoliciesMRT" -Name "DontOfferThroughWUAU" -Type DWord -Value 0
 
-    Write-Status -Symbol "?" -Type $TweakType -Status "For more tweaks, edit the '$PSCommandPath' file, then uncomment '#SomethingHere' code lines" -Warning
+    Write-Status -Types "?", $TweakType -Status "For more tweaks, edit the '$PSCommandPath' file, then uncomment '#SomethingHere' code lines" -Warning
     # Consumes more RAM - Make Windows Defender run in Sandbox Mode (MsMpEngCP.exe and MsMpEng.exe will run on background)
     # Details: https://www.microsoft.com/security/blog/2018/10/26/windows-defender-antivirus-can-now-run-in-a-sandbox/
-    #Write-Status -Symbol "+" -Type $TweakType -Status "Enabling Windows Defender Sandbox mode..."
+    #Write-Status -Types "+", $TweakType -Status "Enabling Windows Defender Sandbox mode..."
     #setx /M MP_FORCE_USE_SANDBOX 1  # Restart the PC to apply the changes, 0 to Revert
 
     # Disable Windows Script Host. CAREFUL, this may break stuff, including software uninstall.
-    #Write-Status -Symbol "+" -Type $TweakType -Status "Disabling Windows Script Host (execution of *.vbs scripts and alike)..."
+    #Write-Status -Types "+", $TweakType -Status "Disabling Windows Script Host (execution of *.vbs scripts and alike)..."
     #Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows Script Host\Settings" -Name "Enabled" -Type DWord -Value 0
 }
 

--- a/src/scripts/optimize-services.ps1
+++ b/src/scripts/optimize-services.ps1
@@ -92,7 +92,7 @@ function Optimize-ServicesRunning() {
     Write-Section -Text "Disabling services from Windows"
 
     If ($Revert) {
-        Write-Status -Symbol "<" -Type "Service" -Status "Reverting the tweaks is set to '$Revert'." -Warning
+        Write-Status -Types "<", "Service" -Status "Reverting the tweaks is set to '$Revert'." -Warning
         $CustomMessage = { "Resetting $Service ($((Get-Service $Service).DisplayName)) as 'Manual' on Startup ..." }
         Set-ServiceStartup -Manual -Services $ServicesToDisabled -Filter $EnableServicesOnSSD -CustomMessage $CustomMessage
     } Else {

--- a/src/scripts/optimize-task-scheduler.ps1
+++ b/src/scripts/optimize-task-scheduler.ps1
@@ -51,7 +51,7 @@ function Optimize-TaskScheduler() {
     Write-Section -Text "Disabling Scheduled Tasks from Windows"
 
     If ($Revert) {
-        Write-Status -Symbol "<" -Type "TaskScheduler" -Status "Reverting the tweaks is set to '$Revert'." -Warning
+        Write-Status -Types "<", "TaskScheduler" -Status "Reverting the tweaks is set to '$Revert'." -Warning
         $CustomMessage = { "Resetting the $ScheduledTask task as 'Ready' ..." }
         Set-ScheduledTaskState -Ready -ScheduledTask $DisableScheduledTasks -CustomMessage $CustomMessage
     } Else {

--- a/src/scripts/optimize-windows-features.ps1
+++ b/src/scripts/optimize-windows-features.ps1
@@ -32,7 +32,7 @@ function Optimize-WindowsFeaturesList() {
     Write-Section -Text "Uninstall Optional Features from Windows"
 
     If ($Revert) {
-        Write-Status -Symbol "<" -Type "OptionalFeature" -Status "Reverting the tweaks is set to '$Revert'." -Warning
+        Write-Status -Types "<", "OptionalFeature" -Status "Reverting the tweaks is set to '$Revert'." -Warning
         $CustomMessage = { "Re-Installing the $OptionalFeature optional feature ..." }
         Set-OptionalFeatureState -Enabled -OptionalFeatures $DisableFeatures -CustomMessage $CustomMessage
     } Else {

--- a/src/scripts/personal-tweaks.ps1
+++ b/src/scripts/personal-tweaks.ps1
@@ -19,7 +19,7 @@ function Register-PersonalTweaksList() {
     $TweakType = "Personal"
 
     If ($Revert) {
-        Write-Status -Symbol "<" -Type $TweakType -Status "Reverting the tweaks is set to '$Revert'." -Warning
+        Write-Status -Types "<", $TweakType -Status "Reverting the tweaks is set to '$Revert'." -Warning
         $Zero = 1
         $One = 0
         $EnableStatus = @(
@@ -47,7 +47,7 @@ function Register-PersonalTweaksList() {
 
     # Show Task Manager details - Applicable to 1607 and later - Although this functionality exist even in earlier versions, the Task Manager's behavior is different there and is not compatible with this tweak
     If ((Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion" -Name CurrentBuild).CurrentBuild -lt 22557) {
-        Write-Status -Symbol "+" -Type $TweakType -Status "Showing task manager details..."
+        Write-Status -Types "+", $TweakType -Status "Showing task manager details..."
         $taskmgr = Start-Process -WindowStyle Hidden -FilePath taskmgr.exe -PassThru
         Do {
             Start-Sleep -Milliseconds 100
@@ -57,16 +57,16 @@ function Register-PersonalTweaksList() {
         $preferences.Preferences[28] = 0
         Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\TaskManager" -Name "Preferences" -Type Binary -Value $preferences.Preferences
     } Else {
-        Write-Status -Symbol "?" -Status "Task Manager patch not run in builds 22557+ due to bug" -Warning
+        Write-Status -Types "?", $TweakType -Status "Task Manager patch not run in builds 22557+ due to bug" -Warning
     }
 
     Write-Section -Text "Windows Explorer Tweaks"
-    Write-Status -Symbol $EnableStatus[1].Symbol -Type $TweakType -Status "$($EnableStatus[1].Status) Quick Access from Windows Explorer..."
+    Write-Status -Types $EnableStatus[1].Symbol, $TweakType -Status "$($EnableStatus[1].Status) Quick Access from Windows Explorer..."
     Set-ItemProperty -Path "$PathToCUExplorer" -Name "ShowFrequent" -Type DWord -Value $Zero
     Set-ItemProperty -Path "$PathToCUExplorer" -Name "ShowRecent" -Type DWord -Value $Zero
     Set-ItemProperty -Path "$PathToCUExplorer" -Name "HubMode" -Type DWord -Value $One
 
-    Write-Status -Symbol "-" -Type $TweakType -Status "Removing 3D Objects from This PC..."
+    Write-Status -Types "-", $TweakType -Status "Removing 3D Objects from This PC..."
     If (Test-Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\MyComputer\NameSpace\{0DB7E03F-FC29-4DC6-9020-FF41B59E513A}") {
         Remove-Item -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\MyComputer\NameSpace\{0DB7E03F-FC29-4DC6-9020-FF41B59E513A}" -Recurse
     }
@@ -74,82 +74,82 @@ function Register-PersonalTweaksList() {
         Remove-Item -Path "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Explorer\MyComputer\NameSpace\{0DB7E03F-FC29-4DC6-9020-FF41B59E513A}" -Recurse
     }
 
-    Write-Status -Symbol "-" -Type $TweakType -Status "Removing 'Edit with Paint 3D' from the Context Menu..."
+    Write-Status -Types "-", $TweakType -Status "Removing 'Edit with Paint 3D' from the Context Menu..."
     $Paint3DFileTypes = @(".3mf", ".bmp", ".fbx", ".gif", ".jfif", ".jpe", ".jpeg", ".jpg", ".png", ".tif", ".tiff")
     ForEach ($FileType in $Paint3DFileTypes) {
         If (Test-Path "Registry::HKEY_CLASSES_ROOT\SystemFileAssociations\$FileType\Shell\3D Edit") {
-            Write-Status -Symbol "-" -Type $TweakType -Status "Removing Paint 3D from file type: $FileType"
+            Write-Status -Types "-", $TweakType -Status "Removing Paint 3D from file type: $FileType"
             Remove-Item -Path "Registry::HKEY_CLASSES_ROOT\SystemFileAssociations\$FileType\Shell\3D Edit" -Recurse
         }
     }
 
-    Write-Status -Symbol $EnableStatus[1].Symbol -Type $TweakType -Status "$($EnableStatus[1].Status) Show Drives without Media..."
+    Write-Status -Types $EnableStatus[1].Symbol, $TweakType -Status "$($EnableStatus[1].Status) Show Drives without Media..."
     Set-ItemProperty -Path "$PathToCUExplorerAdvanced" -Name "HideDrivesWithNoMedia" -Type DWord -Value $Zero
 
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) File Explorer Ads (OneDrive, New Features etc.)..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) File Explorer Ads (OneDrive, New Features etc.)..."
     Set-ItemProperty -Path "$PathToCUExplorerAdvanced" -Name "ShowSyncProviderNotifications" -Type DWord -Value $Zero
 
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) MRU lists (jump lists) of XAML apps in Start Menu..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) MRU lists (jump lists) of XAML apps in Start Menu..."
     Set-ItemProperty -Path "$PathToCUExplorerAdvanced" -Name "Start_TrackDocs" -Type DWord -Value $Zero
     Set-ItemProperty -Path "$PathToCUExplorerAdvanced" -Name "Start_TrackProgs" -Type DWord -Value $Zero
 
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) Aero-Shake Minimize feature..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) Aero-Shake Minimize feature..."
     Set-ItemProperty -Path "$PathToCUExplorerAdvanced" -Name "DisallowShaking" -Type DWord -Value $One
 
-    Write-Status -Symbol "+" -Type $TweakType -Status "Setting Windows Explorer to start on This PC instead of Quick Access..."
+    Write-Status -Types "+", $TweakType -Status "Setting Windows Explorer to start on This PC instead of Quick Access..."
     # [@] (1 = This PC, 2 = Quick access) # DO NOT REVERT, BREAKS EXPLORER.EXE
     Set-ItemProperty -Path "$PathToCUExplorerAdvanced" -Name "LaunchTo" -Type DWord -Value 1
 
-    Write-Status -Symbol $EnableStatus[1].Symbol -Type $TweakType -Status "$($EnableStatus[1].Status) Show hidden files in Explorer..."
+    Write-Status -Types $EnableStatus[1].Symbol, $TweakType -Status "$($EnableStatus[1].Status) Show hidden files in Explorer..."
     Set-ItemProperty -Path "$PathToCUExplorerAdvanced" -Name "Hidden" -Type DWord -Value $One
 
-    Write-Status -Symbol $EnableStatus[1].Symbol -Type $TweakType -Status "$($EnableStatus[1].Status) Showing file transfer details..."
+    Write-Status -Types $EnableStatus[1].Symbol, $TweakType -Status "$($EnableStatus[1].Status) Showing file transfer details..."
     If (!(Test-Path "$PathToCUExplorer\OperationStatusManager")) {
         New-Item -Path "$PathToCUExplorer\OperationStatusManager" -Force | Out-Null
     }
     Set-ItemProperty -Path "$PathToCUExplorer\OperationStatusManager" -Name "EnthusiastMode" -Type DWord -Value $One
 
-    Write-Status -Symbol "-" -Type $TweakType -Status "Disabling '- Shortcut' name after creating a shortcut..."
+    Write-Status -Types "-", $TweakType -Status "Disabling '- Shortcut' name after creating a shortcut..."
     Set-ItemProperty -Path "$PathToCUExplorer" -Name "link" -Value ([byte[]](0x00, 0x00, 0x00, 0x00))
 
     Write-Section -Text "Personalization"
     Write-Section -Text "Task Bar Tweaks"
     Write-Caption -Text "Task Bar - Windows 10 Compatible"
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) the 'Search Box' from taskbar..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) the 'Search Box' from taskbar..."
     # [@] (0 = Hide completely, 1 = Show icon only, 2 = Show long Search Box)
     Set-ItemProperty -Path "$PathToCUSearch" -Name "SearchboxTaskbarMode" -Type DWord -Value $Zero
 
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) the 'Task View' icon from taskbar..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) the 'Task View' icon from taskbar..."
     # [@] (0 = Hide Task view, 1 = Show Task view)
     Set-ItemProperty -Path "$PathToCUExplorerAdvanced" -Name "ShowTaskViewButton" -Type DWord -Value $Zero
 
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) Open on Hover from 'News and Interest' from taskbar..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) Open on Hover from 'News and Interest' from taskbar..."
     If (!(Test-Path "$PathToCUNewsAndInterest")) {
         New-Item -Path "$PathToCUNewsAndInterest" -Force | Out-Null
     }
     # [@] (0 = Disable, 1 = Enable)
     Set-ItemProperty -Path "$PathToCUNewsAndInterest" -Name "ShellFeedsTaskbarOpenOnHover" -Type DWord -Value $Zero
 
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) 'News and Interest' from taskbar..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) 'News and Interest' from taskbar..."
     # [@] (0 = Enable, 1 = Enable Icon only, 2 = Disable)
     Set-ItemProperty -Path "$PathToCUNewsAndInterest" -Name "ShellFeedsTaskbarViewMode" -Type DWord -Value 2
 
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) 'People' icon from taskbar..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) 'People' icon from taskbar..."
     If (!(Test-Path "$PathToCUExplorerAdvanced\People")) {
         New-Item -Path "$PathToCUExplorerAdvanced\People" -Force | Out-Null
     }
     Set-ItemProperty -Path "$PathToCUExplorerAdvanced\People" -Name "PeopleBand" -Type DWord -Value $Zero
 
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) Live Tiles..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) Live Tiles..."
     If (!(Test-Path "$PathToCUPoliciesLiveTiles")) {
         New-Item -Path "$PathToCUPoliciesLiveTiles" -Force | Out-Null
     }
     Set-ItemProperty -Path $PathToCUPoliciesLiveTiles -Name "NoTileApplicationNotification" -Type DWord -Value $One
 
-    Write-Status -Symbol "=" -Type $TweakType -Status "Enabling Auto tray icons..."
+    Write-Status -Types "=", $TweakType -Status "Enabling Auto tray icons..."
     Set-ItemProperty -Path "$PathToCUExplorer" -Name "EnableAutoTray" -Type DWord -Value 1
 
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) 'Meet now' icon on taskbar..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) 'Meet now' icon on taskbar..."
     If (!(Test-Path "$PathToCUPoliciesExplorer")) {
         New-Item -Path "$PathToCUPoliciesExplorer" -Force | Out-Null
     }
@@ -157,65 +157,65 @@ function Register-PersonalTweaksList() {
     Set-ItemProperty -Path "$PathToCUPoliciesExplorer" -Name "HideSCAMeetNow" -Type DWord -Value $One
 
     Write-Caption -Text "Task Bar - Windows 11 Compatible"
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) 'Widgets' icon from taskbar..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) 'Widgets' icon from taskbar..."
     # [@] (0 = Hide Widgets, 1 = Show Widgets)
     Set-ItemProperty -Path "$PathToCUExplorerAdvanced" -Name "TaskbarDa" -Type DWord -Value $Zero
 
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) 'Chat' icon from taskbar..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) 'Chat' icon from taskbar..."
     Set-ItemProperty -Path "$PathToCUExplorerAdvanced" -Name "TaskbarMn" -Type DWord -Value $Zero
 
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) creation of Thumbs.db thumbnail cache files..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) creation of Thumbs.db thumbnail cache files..."
     Set-ItemProperty -Path "$PathToCUExplorerAdvanced" -Name "DisableThumbnailCache" -Type DWord -Value $One
     Set-ItemProperty -Path "$PathToCUExplorerAdvanced" -Name "DisableThumbsDBOnNetworkFolders" -Type DWord -Value $One
 
     Write-Caption -Text "Colors"
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) taskbar transparency..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) taskbar transparency..."
     Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize" -Name "EnableTransparency" -Type DWord -Value $Zero
 
     Write-Section -Text "System"
     Write-Caption -Text "Multitasking"
-    Write-Status -Symbol "-" -Type $TweakType -Status "Disabling Edge multi tabs showing on Alt + Tab..."
+    Write-Status -Types "-", $TweakType -Status "Disabling Edge multi tabs showing on Alt + Tab..."
     Set-ItemProperty -Path "$PathToCUExplorerAdvanced" -Name "MultiTaskingAltTabFilter" -Type DWord -Value 3
 
     Write-Section -Text "Devices"
     Write-Caption -Text "Bluetooth & other devices"
-    Write-Status -Symbol $EnableStatus[1].Symbol -Type $TweakType -Status "$($EnableStatus[1].Status) driver download over metered connections..."
+    Write-Status -Types $EnableStatus[1].Symbol, $TweakType -Status "$($EnableStatus[1].Status) driver download over metered connections..."
     Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\DeviceSetup" -Name "CostedNetworkPolicy" -Type DWord -Value $One
 
     Write-Section -Text "Cortana Tweaks"
-    Write-Status -Symbol $EnableStatus[0].Symbol -Type $TweakType -Status "$($EnableStatus[0].Status) Bing Search in Start Menu..."
+    Write-Status -Types $EnableStatus[0].Symbol, $TweakType -Status "$($EnableStatus[0].Status) Bing Search in Start Menu..."
     Set-ItemProperty -Path "$PathToCUSearch" -Name "BingSearchEnabled" -Type DWord -Value $Zero
     Set-ItemProperty -Path "$PathToCUSearch" -Name "CortanaConsent" -Type DWord -Value $Zero
 
     Write-Section -Text "Ease of Access"
     Write-Caption -Text "Keyboard"
-    Write-Status -Symbol "-" -Type $TweakType -Status "Disabling Sticky Keys..."
+    Write-Status -Types "-", $TweakType -Status "Disabling Sticky Keys..."
     Set-ItemProperty -Path "$PathToCUAccessibility\StickyKeys" -Name "Flags" -Value "506"
     Set-ItemProperty -Path "$PathToCUAccessibility\Keyboard Response" -Name "Flags" -Value "122"
     Set-ItemProperty -Path "$PathToCUAccessibility\ToggleKeys" -Name "Flags" -Value "58"
 
     Write-Section -Text "Microsoft Edge Policies"
     Write-Caption -Text "Privacy, search and services / Address bar and search"
-    Write-Status -Symbol "=" -Type $TweakType -Status "Show me search and site suggestions using my typed characters..."
+    Write-Status -Types "=", $TweakType -Status "Show me search and site suggestions using my typed characters..."
     Remove-ItemProperty -Path "$PathToCUPoliciesEdge" -Name "SearchSuggestEnabled" -Force -ErrorAction SilentlyContinue
 
-    Write-Status -Symbol "=" -Type $TweakType -Status "Show me history and favorite suggestions and other data using my typed characters..."
+    Write-Status -Types "=", $TweakType -Status "Show me history and favorite suggestions and other data using my typed characters..."
     Remove-ItemProperty -Path "$PathToCUPoliciesEdge" -Name "LocalProvidersEnabled" -Force -ErrorAction SilentlyContinue
 
-    Write-Status -Symbol $EnableStatus[1].Symbol -Type $TweakType -Status "$($EnableStatus[1].Status) Error reporting..."
+    Write-Status -Types $EnableStatus[1].Symbol, $TweakType -Status "$($EnableStatus[1].Status) Error reporting..."
     Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting" -Name "Disabled" -Type DWord -Value $Zero
 
     # Adapted from: https://techcommunity.microsoft.com/t5/networking-blog/windows-insiders-gain-new-dns-over-https-controls/ba-p/2494644
-    Write-Status -Symbol "+" -Type $TweakType -Status "Setting up the DNS over HTTPS for Google and Cloudflare (ipv4 and ipv6)..."
+    Write-Status -Types "+", $TweakType -Status "Setting up the DNS over HTTPS for Google and Cloudflare (ipv4 and ipv6)..."
     Set-DnsClientDohServerAddress -ServerAddress ("8.8.8.8", "8.8.4.4", "2001:4860:4860::8888", "2001:4860:4860::8844") -AutoUpgrade $true -AllowFallbackToUdp $true
     Set-DnsClientDohServerAddress -ServerAddress ("1.1.1.1", "1.0.0.1", "2606:4700:4700::1111", "2606:4700:4700::1001") -AutoUpgrade $true -AllowFallbackToUdp $true
 
-    Write-Status -Symbol "+" -Type $TweakType -Status "Setting up the DNS from Cloudflare and Google (ipv4 and ipv6)..."
+    Write-Status -Types "+", $TweakType -Status "Setting up the DNS from Cloudflare and Google (ipv4 and ipv6)..."
     #Get-DnsClientServerAddress # To look up the current config.           # Cloudflare, Google,         Cloudflare,              Google
     Set-DNSClientServerAddress -InterfaceAlias "Ethernet*" -ServerAddresses ("1.1.1.1", "8.8.8.8", "2606:4700:4700::1111", "2001:4860:4860::8888")
     Set-DNSClientServerAddress -InterfaceAlias    "Wi-Fi*" -ServerAddresses ("1.1.1.1", "8.8.8.8", "2606:4700:4700::1111", "2001:4860:4860::8888")
 
-    Write-Status -Symbol "+" -Type $TweakType -Status "Bringing back F8 alternative Boot Modes..."
+    Write-Status -Types "+", $TweakType -Status "Bringing back F8 alternative Boot Modes..."
     bcdedit /set `{current`} bootmenupolicy Legacy
 
     Write-Section -Text "Power Plan Tweaks"
@@ -231,19 +231,19 @@ function Register-PersonalTweaksList() {
     $TimeoutHibernateBattery = 15
     $TimeoutHibernatePluggedIn = 30
 
-    Write-Status -Symbol "+" -Type $TweakType -Status "Setting the Monitor Timeout to AC: $TimeoutScreenPluggedIn and DC: $TimeoutScreenBattery..."
+    Write-Status -Types "+", $TweakType -Status "Setting the Monitor Timeout to AC: $TimeoutScreenPluggedIn and DC: $TimeoutScreenBattery..."
     powercfg -Change Monitor-Timeout-AC $TimeoutScreenPluggedIn
     powercfg -Change Monitor-Timeout-DC $TimeoutScreenBattery
 
-    Write-Status -Symbol "+" -Type $TweakType -Status "Setting the Standby Timeout to AC: $TimeoutStandByPluggedIn and DC: $TimeoutStandByBattery..."
+    Write-Status -Types "+", $TweakType -Status "Setting the Standby Timeout to AC: $TimeoutStandByPluggedIn and DC: $TimeoutStandByBattery..."
     powercfg -Change Standby-Timeout-AC $TimeoutStandByPluggedIn
     powercfg -Change Standby-Timeout-DC $TimeoutStandByBattery
 
-    Write-Status -Symbol "+" -Type $TweakType -Status "Setting the Disk Timeout to AC: $TimeoutDiskPluggedIn and DC: $TimeoutDiskBattery..."
+    Write-Status -Types "+", $TweakType -Status "Setting the Disk Timeout to AC: $TimeoutDiskPluggedIn and DC: $TimeoutDiskBattery..."
     powercfg -Change Disk-Timeout-AC $TimeoutDiskPluggedIn
     powercfg -Change Disk-Timeout-DC $TimeoutDiskBattery
 
-    Write-Status -Symbol "+" -Type $TweakType -Status "Setting the Hibernate Timeout to AC: $TimeoutHibernatePluggedIn and DC: $TimeoutHibernateBattery..."
+    Write-Status -Types "+", $TweakType -Status "Setting the Hibernate Timeout to AC: $TimeoutHibernatePluggedIn and DC: $TimeoutHibernateBattery..."
     powercfg -Change Hibernate-Timeout-AC $TimeoutHibernatePluggedIn
     powercfg -Change Hibernate-Timeout-DC $TimeoutHibernateBattery
 }

--- a/src/scripts/remove-xbox.ps1
+++ b/src/scripts/remove-xbox.ps1
@@ -24,13 +24,13 @@ function Remove-Xbox() {
         "Microsoft.Xbox.TCUI"               # Xbox Live API communication (Xbox Dependency)
     )
 
-    Write-Status -Symbol "-" -Type $TweakType -Status "Disabling ALL Xbox Services..."
+    Write-Status -Types "-", $TweakType -Status "Disabling ALL Xbox Services..."
     Set-ServiceStartup -Disabled -Services $XboxServices
 
-    Write-Status -Symbol "-" -Type $TweakType -Status "Wiping Xbox Apps completely from Windows..."
+    Write-Status -Types "-", $TweakType -Status "Wiping Xbox Apps completely from Windows..."
     Remove-UWPAppx -AppxPackages $XboxApps
 
-    Write-Status -Symbol "-" -Type $TweakType -Status "Disabling Xbox Game Bar & Game DVR..."
+    Write-Status -Types "-", $TweakType -Status "Disabling Xbox Game Bar & Game DVR..."
     Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\PolicyManager\default\ApplicationManagement\AllowGameDVR" -Name "value" -Type DWord -Value 0
     Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\GameDVR" -Name "AppCaptureEnabled" -Type DWord -Value 0
     Set-ItemProperty -Path "HKCU:\System\GameConfigStore" -Name "GameDVR_Enabled" -Type DWord -Value 0

--- a/src/scripts/repair-windows.ps1
+++ b/src/scripts/repair-windows.ps1
@@ -47,7 +47,7 @@ function Repair-System() {
     Write-Caption -Text "Re-registering all Windows Apps via AppXManifest.xml ..."
     Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "EnableXamlStartMenu" -Type Dword -Value 0
     Get-AppxPackage -AllUsers | ForEach-Object {
-        Write-Status -Symbol "@" -Status "Trying to register package: $($_.InstallLocation)"
+        Write-Status -Types "@" -Status "Trying to register package: $($_.InstallLocation)"
         Add-AppxPackage -DisableDevelopmentMode -Register "$($_.InstallLocation)\AppXManifest.xml"
     }
     Write-Caption -Text "Restarting Windows Explorer..."
@@ -55,11 +55,11 @@ function Repair-System() {
 
     Write-Section -Text "Solving Network problems"
     Write-Caption -Text "Resetting IPv4 and IPv6 addresses..."
-    Write-Status -Symbol "?" -Status "Your internet may fall during the process, please be patient..." -Warning
+    Write-Status -Types "?" -Status "Your internet may fall during the process, please be patient..." -Warning
     ipconfig -Release | Out-Host
     ipconfig -Release6 | Out-Host
     Write-Caption -Text "Renewing IPv4 address..."
-    Write-Status -Symbol "?" -Status "This may take time, please be patient..." -Warning
+    Write-Status -Types "?" -Status "This may take time, please be patient..." -Warning
     ipconfig -Renew *Ethernet* | Out-Host
     Write-Caption -Text "Renewing IPv6 address..."
     ipconfig -Renew6 *Ethernet* | Out-Host

--- a/src/scripts/silent-debloat-softwares.ps1
+++ b/src/scripts/silent-debloat-softwares.ps1
@@ -6,7 +6,7 @@ Import-Module -DisableNameChecking $PSScriptRoot\..\lib\"title-templates.psm1"
 function Use-DebloatSoftware() {
     $AdwCleanerDl = "https://downloads.malwarebytes.com/file/adwcleaner"
     $AdwCleanerOutput = Request-FileDownload -FileURI $AdwCleanerDl -OutputFile "adwcleaner.exe"
-    Write-Status -Symbol "+" -Status "Running MalwareBytes AdwCleaner scanner..."
+    Write-Status -Types "+" -Status "Running MalwareBytes AdwCleaner scanner..."
     Start-Process -FilePath $AdwCleanerOutput -ArgumentList "/eula", "/clean", "/noreboot" -Wait
     Remove-Item $AdwCleanerOutput -Force
 
@@ -14,7 +14,7 @@ function Use-DebloatSoftware() {
     $ShutUpOutput = Request-FileDownload -FileURI $ShutUpDl -OutputFolder "ShutUp10" -OutputFile "OOSU10.exe"
     $ShutUpFolder = "$PSScriptRoot\..\tmp\ShutUp10"
     Push-Location -Path $ShutUpFolder
-    Write-Status -Symbol "+" -Status "Running ShutUp10 and applying Recommended settings..."
+    Write-Status -Types "+" -Status "Running ShutUp10 and applying Recommended settings..."
     Start-Process -FilePath $ShutUpOutput -ArgumentList "ooshutup10.cfg", "/quiet" -Wait # Wait until the process closes #
     Remove-Item "$ShutUpOutput" -Force                                                   # Leave no traces
     Pop-Location

--- a/src/utils/disable-god-mode.ps1
+++ b/src/utils/disable-god-mode.ps1
@@ -1,7 +1,7 @@
 Import-Module -DisableNameChecking $PSScriptRoot\..\lib\"title-templates.psm1"
 
 function Main() {
-    Write-Status -Symbol "@" -Status "Disabling God Mode hidden folder..." -Warning
+    Write-Status -Types "@" -Status "Disabling God Mode hidden folder..." -Warning
     Write-Host @"
 ###############################################################################
 #       _______  _______  ______     __   __  _______  ______   _______       #

--- a/src/utils/disable-search-idx-service.ps1
+++ b/src/utils/disable-search-idx-service.ps1
@@ -1,5 +1,7 @@
+Import-Module -DisableNameChecking $PSScriptRoot\..\lib\"title-templates.psm1"
+
 function Main() {
-    Write-Host "[-] [Services] Disabling Search Indexing (Recommended for HDDs)..."
+    Write-Status -Types "-", "Service" -Status "Disabling Search Indexing (Recommended for HDDs)..."
     Get-Service -Name "WSearch" -ErrorAction SilentlyContinue | Set-Service -StartupType Disabled
     Stop-Service "WSearch" -Force -NoWait
 }

--- a/src/utils/disable-shutdown-pc-shortcut.ps1
+++ b/src/utils/disable-shutdown-pc-shortcut.ps1
@@ -4,7 +4,7 @@ Import-Module -DisableNameChecking $PSScriptRoot\..\lib\"title-templates.psm1"
 function Main() {
     $DesktopPath = [Environment]::GetFolderPath("Desktop");
 
-    Write-Status -Symbol "@" -Status "Removing the shortcut to shutdown the computer on the Desktop..." -Warning
+    Write-Status -Types "@" -Status "Removing the shortcut to shutdown the computer on the Desktop..." -Warning
     Remove-Item -Path "$DesktopPath\Shutdown Computer.lnk"
 }
 

--- a/src/utils/enable-god-mode.ps1
+++ b/src/utils/enable-god-mode.ps1
@@ -1,7 +1,7 @@
 Import-Module -DisableNameChecking $PSScriptRoot\..\lib\"title-templates.psm1"
 
 function Main() {
-    Write-Status -Symbol "@" -Status "Enabling God Mode hidden folder on Desktop..."
+    Write-Status -Types "@" -Status "Enabling God Mode hidden folder on Desktop..."
     Write-Host @"
 ###############################################################################
 #       _______  _______  ______     __   __  _______  ______   _______       #

--- a/src/utils/enable-search-idx-service.ps1
+++ b/src/utils/enable-search-idx-service.ps1
@@ -1,5 +1,7 @@
+Import-Module -DisableNameChecking $PSScriptRoot\..\lib\"title-templates.psm1"
+
 function Main() {
-    Write-Host "[+] [Services] Enabling Search Indexing (Recommended for SSDs)..."
+    Write-Status -Types "+", "Service" -Status "Enabling Search Indexing (Recommended for SSDs)..."
     Get-Service -Name "WSearch" -ErrorAction SilentlyContinue | Set-Service -StartupType Automatic
     Start-Service "WSearch"
 }

--- a/src/utils/enable-shutdown-pc-shortcut.ps1
+++ b/src/utils/enable-shutdown-pc-shortcut.ps1
@@ -11,7 +11,7 @@ function Main() {
     $Arguments = "-s -f -t 0"
     $Hotkey = "CTRL+ALT+F12"
 
-    Write-Status -Symbol "@" -Status "Creating a shortcut to shutdown the computer on the Desktop..."
+    Write-Status -Types "@" -Status "Creating a shortcut to shutdown the computer on the Desktop..."
     New-Shortcut -SourcePath $SourcePath -ShortcutPath $ShortcutPath -Description $Description -IconLocation $IconLocation -Arguments $Arguments -Hotkey $Hotkey
 }
 

--- a/src/utils/git-gnupg-ssh-keys-setup.ps1
+++ b/src/utils/git-gnupg-ssh-keys-setup.ps1
@@ -154,9 +154,9 @@ function Set-GPGKey() {
     Write-Host "Then: [your passphrase again] [ENTER]." -ForegroundColor Cyan
     gpg --full-generate-key
 
-    Write-Status -Symbol "@" -Status "If you want to delete unwanted keys, this is just for reference"
-    Write-Status -Symbol "@" -Status 'gpg --delete-secret-keys $(git config --global user.name)'
-    Write-Status -Symbol "@" -Status 'gpg --delete-keys $(git config --global user.name)'
+    Write-Status -Types "@" -Status "If you want to delete unwanted keys, this is just for reference"
+    Write-Status -Types "@" -Status 'gpg --delete-secret-keys $(git config --global user.name)'
+    Write-Status -Types "@" -Status 'gpg --delete-keys $(git config --global user.name)'
 
     Write-Host "Copying all files to $GnuPGPath"
     Copy-Item -Path "$GnuPGGeneratePath/*" -Destination "$GnuPGPath/" -Recurse

--- a/src/utils/install-archwsl.ps1
+++ b/src/utils/install-archwsl.ps1
@@ -8,19 +8,19 @@ function ArchWSLInstall() {
     ForEach ($OSArch in $OSArchList) {
         If ($OSArch -like "x64") {
             $CertOutput = Get-APIFile -URI "https://api.github.com/repos/yuk7/ArchWSL/releases/latest" -ObjectProperty "assets" -FileNameLike "ArchWSL-AppX_*_$OSArch.cer" -PropertyValue "browser_download_url" -OutputFile "ArchWSL.cer"
-            Write-Status -Symbol "+" -Status "Installing ArchWSL Certificate ($OSArch) ..."
+            Write-Status -Types "+" -Status "Installing ArchWSL Certificate ($OSArch) ..."
             Import-Certificate -FilePath $CertOutput -CertStoreLocation Cert:\LocalMachine\Root | Out-Host
-            Write-Status -Symbol "?" -Status "The certificate needs to be installed manually, the cmdlet didn't work for some reason ..." -Warning
-            Write-Status -Symbol "@" -Status "Steps: Install Certificate... (Next) > Select Local Machine (Next) > Next > Finish > OK" -Warning
+            Write-Status -Types "?" -Status "The certificate needs to be installed manually, the cmdlet didn't work for some reason ..." -Warning
+            Write-Status -Types "@" -Status "Steps: Install Certificate... (Next) > Select Local Machine (Next) > Next > Finish > OK" -Warning
             Start-Process -FilePath "$CertOutput" -Wait
             $ArchWSLOutput = Get-APIFile -URI "https://api.github.com/repos/yuk7/ArchWSL/releases/latest" -ObjectProperty "assets" -FileNameLike "ArchWSL-AppX_*_$OSArch.appx" -PropertyValue "browser_download_url" -OutputFile "ArchWSL.appx"
-            Write-Status -Symbol "+" -Status "Installing ArchWSL ($OSArch) ..."
+            Write-Status -Types "+" -Status "Installing ArchWSL ($OSArch) ..."
             Add-AppxPackage -Path $ArchWSLOutput
-            Write-Status -Symbol "@" -Status "Removing downloaded files ..."
+            Write-Status -Types "@" -Status "Removing downloaded files ..."
             Remove-Item -Path $CertOutput
             Remove-Item -Path $ArchWSLOutput
         } Else {
-            Write-Status -Symbol "?" -Status "$OSArch is NOT supported!" -Warning
+            Write-Status -Types "?" -Status "$OSArch is NOT supported!" -Warning
             Break
         }
     }

--- a/src/utils/install-nerd-fonts.ps1
+++ b/src/utils/install-nerd-fonts.ps1
@@ -6,14 +6,14 @@ function Install-NerdFont() {
     Push-Location -Path "$PSScriptRoot\..\tmp"
     mkdir "Fonts" | Out-Null
 
-    Write-Status -Symbol "@" -Status "Downloading JetBrains Mono ..."
+    Write-Status -Types "@" -Status "Downloading JetBrains Mono ..."
     Install-JetBrainsMono
-    Write-Status -Symbol "@" -Status "Downloading MesloLGS NF ..."
+    Write-Status -Types "@" -Status "Downloading MesloLGS NF ..."
     Install-MesloLGS
 
-    Write-Status -Symbol "+" -Status "Installing downloaded fonts on $pwd\Fonts ..."
+    Write-Status -Types "+" -Status "Installing downloaded fonts on $pwd\Fonts ..."
     Install-Font -FontSourceFolder "Fonts"
-    Write-Status -Symbol "@" -Status "Cleaning up ..."
+    Write-Status -Types "@" -Status "Cleaning up ..."
     Remove-Item -Path "Fonts" -Recurse
     Pop-Location
 }

--- a/src/utils/install-onedrive.ps1
+++ b/src/utils/install-onedrive.ps1
@@ -1,5 +1,7 @@
+Import-Module -DisableNameChecking $PSScriptRoot\..\lib\"title-templates.psm1"
+
 function Install-OneDrive() {
-    Write-Host "[+] Installing OneDrive..."
+    Write-Status -Types "+" -Status "Installing OneDrive..."
     Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\OneDrive" -Name "DisableFileSyncNGSC" -Type DWord -Value 0
     Start-Process -FilePath "$env:SystemRoot\SysWOW64\OneDriveSetup.exe"
 }

--- a/src/utils/install-wslg-or-preview.ps1
+++ b/src/utils/install-wslg-or-preview.ps1
@@ -8,30 +8,30 @@ function Install-WSLPreview() {
 
     $TweakType = "WSL"
 
-    Write-Status -Symbol "+" -Type $TweakType -Status "Enabling Install updates to other Microsoft products (auto-update WSL and other products)..."
+    Write-Status -Types "+", $TweakType -Status "Enabling Install updates to other Microsoft products (auto-update WSL and other products)..."
     # [@] (0 = Do not install updates to other Microsoft products , 1 = Install updates to other Microsoft products)
     Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" -Name "AllowMUUpdateService" -Type DWord -Value 1
 
-    Write-Status -Symbol "+" -Type $TweakType -Status "Installing VirtualMachinePlatform on Optional Features ..."
+    Write-Status -Types "+", $TweakType -Status "Installing VirtualMachinePlatform on Optional Features ..."
     Get-WindowsOptionalFeature -Online -FeatureName "VirtualMachinePlatform" | Where-Object State -Like "Disabled*" | Enable-WindowsOptionalFeature -Online -NoRestart # VM Platform
-    Write-Status -Symbol "+" -Type $TweakType -Status "Installing HypervisorPlatform on Optional Features ..."
+    Write-Status -Types "+", $TweakType -Status "Installing HypervisorPlatform on Optional Features ..."
     Get-WindowsOptionalFeature -Online -FeatureName "HypervisorPlatform" | Where-Object State -Like "Disabled*" | Enable-WindowsOptionalFeature -Online -NoRestart # Hypervisor Platform from Windows
 
     Try {
-        Write-Status -Symbol "?" -Type $TweakType "Installing WSL Preview from MS Store for Windows 11+ ..." -Warning
+        Write-Status -Types "?", $TweakType "Installing WSL Preview from MS Store for Windows 11+ ..." -Warning
         Write-Host "[?] Press 'Y' and ENTER to continue if stuck (Winget bug) ..." -ForegroundColor Magenta -BackgroundColor Black
         $CheckExistenceBlock = { Install-Software -Name "WSL Preview (Win 11+)" -Packages "9P9TQF7MRM4R" -ViaMSStore -NoDialog }
         $err = (Invoke-Expression "$CheckExistenceBlock") | Out-Host
         If (($LASTEXITCODE)) { throw $err } # !! 0 = False, 1 = True
 
-        Write-Status -Symbol "-" -Type $TweakType -Status "Uninstalling WSL from Optional Features ..."
+        Write-Status -Types "-", $TweakType -Status "Uninstalling WSL from Optional Features ..."
         Get-WindowsOptionalFeature -Online -FeatureName "Microsoft-Windows-Subsystem-Linux" | Where-Object State -Like "Enabled" | Disable-WindowsOptionalFeature -Online -NoRestart
     } Catch {
-        Write-Status -Symbol "?" -Type $TweakType -Status "Couldn't install WSL Preview, you must be at least on Windows 11 ..." -Warning
+        Write-Status -Types "?", $TweakType -Status "Couldn't install WSL Preview, you must be at least on Windows 11 ..." -Warning
         Install-WSLTwoAndG
     }
 
-    Write-Status -Symbol "@" -Type $TweakType -Status "Updating WSL (if possible) ..."
+    Write-Status -Types "@", $TweakType -Status "Updating WSL (if possible) ..."
     wsl --update
 }
 
@@ -42,29 +42,29 @@ function Install-WSLTwoAndG() {
 
     If ([System.Environment]::OSVersion.Version.Build -eq 14393) {
         # 1607 needs developer mode to be enabled for older Windows 10 versions
-        Write-Status -Symbol "+" -Type $TweakType -Status "Enabling Development mode w/out license and trusted apps (Win 10 1607)"
+        Write-Status -Types "+", $TweakType -Status "Enabling Development mode w/out license and trusted apps (Win 10 1607)"
         Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" -Name "AllowDevelopmentWithoutDevLicense" -Type DWord -Value 1
         Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" -Name "AllowAllTrustedApps" -Type DWord -Value 1
     }
 
-    Write-Status -Symbol "+" -Type $TweakType -Status "Installing Microsoft-Windows-Subsystem-Linux ..."
+    Write-Status -Types "+", $TweakType -Status "Installing Microsoft-Windows-Subsystem-Linux ..."
     Get-WindowsOptionalFeature -Online -FeatureName "Microsoft-Windows-Subsystem-Linux" | Where-Object State -Like "Disabled*" | Enable-WindowsOptionalFeature -Online -NoRestart # WSL (VT-d (Intel) or SVM (AMD) need to be enabled on BIOS)
 
     ForEach ($OSArch in $OSArchList) {
         If ($OSArch -like "x64" -or "arm64") {
             $WSLOutput = Request-FileDownload -FileURI "https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_$OSArch.msi" -OutputFile "wsl_update.msi"
-            Write-Status -Symbol "+" -Type $TweakType -Status "Installing WSL Update ($OSArch)..."
+            Write-Status -Types "+", $TweakType -Status "Installing WSL Update ($OSArch)..."
             Start-Process -FilePath $WSLOutput -ArgumentList "/passive" -Wait
             Remove-Item -Path $WSLOutput
 
             wsl --set-default-version 2 | Out-Host
 
             $WSLgOutput = Get-APIFile -URI "https://api.github.com/repos/microsoft/wslg/releases/latest" -ObjectProperty "assets" -FileNameLike "*$OSArch*.msi" -PropertyValue "browser_download_url" -OutputFile "wsl_graphics_support.msi"
-            Write-Status -Symbol "+" -Type $TweakType -Status "Installing WSL Graphics update (Insider only) ($OSArch)..."
+            Write-Status -Types "+", $TweakType -Status "Installing WSL Graphics update (Insider only) ($OSArch)..."
             Start-Process -FilePath $WSLgOutput -ArgumentList "/passive" -Wait
             Remove-Item -Path $WSLgOutput
         } Else {
-            Write-Status -Symbol "?" -Type $TweakType -Status "$OSArch is NOT supported!" -Warning
+            Write-Status -Types "?", $TweakType -Status "$OSArch is NOT supported!" -Warning
             Break
         }
     }


### PR DESCRIPTION
### Changes on this PR
- Accepts `-Types` instead of `-Symbol` and `-Type`
  - Use case: 
```powershell
Write-Status -Types "-", "Service" -Status "Disabling WSearch indexing service..."
# Instead of using
Write-Status -Types "-" -Type "Service" -Status "Disabling WSearch indexing service..."
```
- Customize System Features tweaks now show **"*"** instead of **"(Default)"** or **"(D.)"**